### PR TITLE
Add support for custom redirect / notFound logic in getServerSideProps

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,9 @@ export const getServerSideProps = withAuthUserTokenSSR({
   })
   const data = await response.json()
   return {
-    thing: data.thing,
+    props: {
+      thing: data.thing
+    }
   }
 })
 

--- a/README.md
+++ b/README.md
@@ -446,6 +446,7 @@ A method that calls Firebase's [`signOut`](https://firebase.google.com/docs/refe
 
 We expect some apps will need some additional customization that's not currently available:
 
+* **Dynamic redirect destinations:** Currently, built-in *dynamic* redirects aren't fully supported, because `authPageURL` and `appPageURL` are static. We may want to allow a function so the app can determine the redirect destination based on, for example, a URL parameter value. Check out [this enhancement](https://github.com/gladly-team/next-firebase-auth/issues/57) for details. It is however possible to perform custom routing at SSR by leveraging [the officially supported](https://nextjs.org/docs/basic-features/data-fetching#getserversideprops-server-side-rendering) `notFound` and `redirect` objects that `getServerSideProps` may return.
 * **Supporting custom claims:** Currently, the `AuthUser` object does not include any Firebase custom claims.
 * **Allowing custom logic for calling login/logout API endpoints:** Currently, this package doesn't allow customizing how we call login and logout API endpoints. Some developers may need to customize this to, for example, use a custom fetcher or custom headers.
 * **Supporting custom session logic:** Currently, this package doesn't allow using a custom cookie or session module. Some developers may need this flexibility to, for example, keep auth user data in server-side session storage.

--- a/example/components/DemoPageLinks.js
+++ b/example/components/DemoPageLinks.js
@@ -29,6 +29,9 @@ const DemoPageLinks = () => (
       <Link href="/ssr-no-token">
         <a style={styles.linkAnchor}>Example: SSR + no ID token</a>
       </Link>
+      <Link href="/ssr-custom-routing">
+        <a style={styles.linkAnchor}>Example: SSR + custom routing</a>
+      </Link>
       <Link href="/static-auth-required-loader">
         <a style={styles.linkAnchor}>
           Example: static + loader + data fetching with ID token

--- a/example/pages/ssr-auth-required.js
+++ b/example/pages/ssr-auth-required.js
@@ -59,7 +59,9 @@ export const getServerSideProps = withAuthUserTokenSSR({
     )
   }
   return {
-    favoriteColor: data.favoriteColor,
+    props: {
+      favoriteColor: data.favoriteColor,
+    },
   }
 })
 

--- a/example/pages/ssr-custom-routing.js
+++ b/example/pages/ssr-custom-routing.js
@@ -26,10 +26,19 @@ const Demo = ({ emailVerified }) => {
             server-side redirect (307) to the login page if the user is not
             authenticated.
           </p>
-          <p>If authenticated, but no email, it will generate a 404 page.</p>
           <p>
-            If authenticated, but email is not verified, it performs a custom
-            redirect to the login page and injects query parameters in the URL.
+            The custom logic also does the following (which does not actually
+            work, it's only for the purpose of illustrating what can be done):
+            <ul>
+              <li>
+                If authenticated, but no email, it will generate a 404 page.
+              </li>
+              <li>
+                If authenticated, but email is not verified, it performs a
+                custom redirect to the login page and injects query parameters
+                in the URL.
+              </li>
+            </ul>
           </p>
           <p>
             This page leverages the standard `redirect` and 'notFound' objects
@@ -46,10 +55,10 @@ const Demo = ({ emailVerified }) => {
 // Here we don't rely on the built-in REDIRECT_TO_LOGIN option of
 // withAuthUserSSR, we do custom checks on the AuthUser and dynamic routing accordingly.
 export const getServerSideProps = withAuthUserSSR()(async (ctx) => {
-  // Retrieve AuthUser (that was injected by withAuthUserSSR from the context.
+  // Retrieve AuthUser (that was injected by withAuthUserSSR) from the context.
   const { AuthUser } = ctx
   // If the user is not authenticated at all, do a simple custom redirect
-  // to login page (equivalent to REDIRECT_TO_LOGIN).
+  // to login page (equivalent to REDIRECT_TO_LOGIN parameter of withAuthUserSSR).
   if (!AuthUser || !AuthUser.id) {
     return {
       redirect: {
@@ -59,7 +68,7 @@ export const getServerSideProps = withAuthUserSSR()(async (ctx) => {
     }
   }
   // If the user is authenticated but has no email, let's assume that's a
-  // big crime for the app, so display a 404 page
+  // big crime for the app, so display a 404 page.
   if (!AuthUser.email) {
     return {
       notFound: true,

--- a/example/pages/ssr-custom-routing.js
+++ b/example/pages/ssr-custom-routing.js
@@ -1,0 +1,91 @@
+import React from 'react'
+import { useAuthUser, withAuthUser, withAuthUserSSR } from 'next-firebase-auth'
+import Header from '../components/Header'
+import DemoPageLinks from '../components/DemoPageLinks'
+
+const styles = {
+  content: {
+    padding: 32,
+  },
+  infoTextContainer: {
+    marginBottom: 32,
+  },
+}
+
+const Demo = ({ emailVerified }) => {
+  const AuthUser = useAuthUser()
+  return (
+    <div>
+      <Header email={AuthUser.email} signOut={AuthUser.signOut} />
+      <div style={styles.content}>
+        <div style={styles.infoTextContainer}>
+          <h3>Example: SSR + custom routing</h3>
+          <p>
+            This page requires authentication. It will do a{' '}
+            <strong>custom/dynamic</strong>
+            server-side redirect (307) to the login page if the user is not
+            authenticated.
+          </p>
+          <p>If authenticated, but no email, it will generate a 404 page.</p>
+          <p>
+            If authenticated, but email is not verified, it performs a custom
+            redirect to the login page and injects query parameters in the URL.
+          </p>
+          <p>
+            This page leverages the standard `redirect` and 'notFound' objects
+            returned by `getServerSideProps` to perform the custom routing.
+          </p>
+          <p>User's email is verified: {emailVerified ? 'yes' : 'no'}</p>
+        </div>
+        <DemoPageLinks />
+      </div>
+    </div>
+  )
+}
+
+// Here we don't rely on the built-in REDIRECT_TO_LOGIN option of
+// withAuthUserSSR, we do custom checks on the AuthUser and dynamic routing accordingly.
+export const getServerSideProps = withAuthUserSSR()(async (ctx) => {
+  // Retrieve AuthUser (that was injected by withAuthUserSSR from the context.
+  const { AuthUser } = ctx
+  // If the user is not authenticated at all, do a simple custom redirect
+  // to login page (equivalent to REDIRECT_TO_LOGIN).
+  if (!AuthUser || !AuthUser.id) {
+    return {
+      redirect: {
+        destination: '/login',
+        permanent: false,
+      },
+    }
+  }
+  // If the user is authenticated but has no email, let's assume that's a
+  // big crime for the app, so display a 404 page
+  if (!AuthUser.email) {
+    return {
+      notFound: true,
+    }
+  }
+  // If the user is authenticated, has an email, but the email is not verified,
+  // we perform a custom redirect to the login page and inject query parameters
+  // that the login page must handle.
+  if (!AuthUser.emailVerified) {
+    return {
+      redirect: {
+        destination: `/login?verifyEmail=true&thenGoToPage=${encodeURIComponent(
+          ctx.resolvedUrl
+        )}`,
+        permanent: false,
+      },
+    }
+  }
+  // And finally if everything is OK, we return a props object as usual.
+  return {
+    props: {
+      email: AuthUser.email,
+      emailVerified: AuthUser.emailVerified,
+      someOtherProp: 'any other data can be added',
+    },
+  }
+})
+
+export default withAuthUser()(Demo)

--- a/example/pages/ssr-no-token.js
+++ b/example/pages/ssr-no-token.js
@@ -65,7 +65,9 @@ export const getServerSideProps = withAuthUserSSR({
     )
   }
   return {
-    favoriteColor: data.favoriteColor,
+    props: {
+      favoriteColor: data.favoriteColor,
+    },
   }
 })
 

--- a/src/__tests__/withAuthUserTokenSSR.test.js
+++ b/src/__tests__/withAuthUserTokenSSR.test.js
@@ -637,8 +637,10 @@ describe('withAuthUserTokenSSR: redirect and composed prop logic', () => {
     }).serialize()
     const withAuthUserTokenSSR = require('src/withAuthUserTokenSSR').default
     const mockGetSSPFunc = jest.fn((ctx) => ({
-      here: ['is', 'a', 'prop'],
-      userEmail: ctx.AuthUser.email,
+      props: {
+        here: ['is', 'a', 'prop'],
+        userEmail: ctx.AuthUser.email,
+      },
     }))
     const func = withAuthUserTokenSSR()(mockGetSSPFunc)
     const props = await func(createMockNextContext())

--- a/src/withAuthUserTokenSSR.js
+++ b/src/withAuthUserTokenSSR.js
@@ -116,20 +116,22 @@ const withAuthUserTokenSSR = (
   let returnData = { props: { AuthUserSerialized } }
 
   // Evaluate the composed getServerSideProps().
-  let composedProps = {}
   if (getServerSidePropsFunc) {
     // Add the AuthUser to Next.js context so pages can use
     // it in `getServerSideProps`, if needed.
     ctx.AuthUser = AuthUser
-    composedProps = await getServerSidePropsFunc(ctx)
-    if (composedProps.props) {
-      // If composedProps does have a valid props object, we inject AuthUser in there
-      returnData = { ...composedProps, ...returnData }
-    } else if (composedProps.notFound || composedProps.redirect) {
-      // If composedProps returned a 'notFound' or 'redirect' key
-      // (as per official doc: https://nextjs.org/docs/basic-features/data-fetching#getserversideprops-server-side-rendering)
-      // it means it contains a custom dynamic routing logic that should not be overwritten
-      returnData = { ...composedProps }
+    const composedProps = (await getServerSidePropsFunc(ctx)) || {}
+    if (composedProps) {
+      if (composedProps.props) {
+        // If composedProps does have a valid props object, we inject AuthUser in there
+        returnData = { ...composedProps }
+        returnData.props.AuthUserSerialized = AuthUserSerialized
+      } else if (composedProps.notFound || composedProps.redirect) {
+        // If composedProps returned a 'notFound' or 'redirect' key
+        // (as per official doc: https://nextjs.org/docs/basic-features/data-fetching#getserversideprops-server-side-rendering)
+        // it means it contains a custom dynamic routing logic that should not be overwritten
+        returnData = { ...composedProps }
+      }
     }
   }
 


### PR DESCRIPTION
The idea behind this feature is simple.

If the `getServerSideProps` function (provided by the consumer) is specifically built to **not** return `props`, but rather perform a custom routing action (by returning an object with a `redirect` or `notFound` key as per [the official doc](https://nextjs.org/docs/basic-features/data-fetching#getserversideprops-server-side-rendering)), we should let it. And we should certainly not override the object as the `AuthUser` is not wanted and useless is this scenario.

- Tested and working locally
- Added 2 tests scenarios to cover those scenarios
- All tests passing