### PR TITLE
fix: use correct path for index.d.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,6 @@
   },
   "files": [
     "/build",
-    "./index.d.ts"
+    "index.d.ts"
   ]
 }


### PR DESCRIPTION
I just pulled down the 0.12.1 version, but the `index.d.ts` file wasn't included in the package. I looked at the npm docs, and I'm pretty sure I made a mistake when I included `./` at the beginning of the file path. That'll teach me to code while half asleep. :-D