### PR TITLE
Only init the Firebase admin app when it's needed

### DIFF
--- a/src/__tests__/firebaseAdmin.test.js
+++ b/src/__tests__/firebaseAdmin.test.js
@@ -1,10 +1,12 @@
-import * as admin from 'firebase-admin'
 import { createMockFirebaseUserAdminSDK } from 'src/testHelpers/authUserInputs'
 import createMockFetchResponse from 'src/testHelpers/createMockFetchResponse'
 import createAuthUser from 'src/createAuthUser'
 import { setConfig } from 'src/config'
 import createMockConfig from 'src/testHelpers/createMockConfig'
+import getFirebaseAdminApp from 'src/initFirebaseAdminSDK'
 
+// We're not mocking initFirebaseAdminSDK.js, instead just mocking
+// the underyling Firebase admin app.
 jest.mock('firebase-admin')
 
 beforeEach(() => {
@@ -33,6 +35,7 @@ describe('verifyIdToken', () => {
       firebaseUserAdminSDK: mockFirebaseUser,
       token: 'some-token',
     })
+    const admin = getFirebaseAdminApp()
     admin.auth().verifyIdToken.mockResolvedValue(mockFirebaseUser)
     const response = await verifyIdToken('some-token')
     expect(response).toEqual({
@@ -46,6 +49,7 @@ describe('verifyIdToken', () => {
   it('returns an AuthUser with the same token when the token has not expired', async () => {
     const { verifyIdToken } = require('src/firebaseAdmin')
     const mockFirebaseUser = createMockFirebaseUserAdminSDK()
+    const admin = getFirebaseAdminApp()
     admin.auth().verifyIdToken.mockResolvedValue(mockFirebaseUser)
     const AuthUser = await verifyIdToken('some-token')
     const token = await AuthUser.getIdToken()
@@ -73,6 +77,7 @@ describe('verifyIdToken', () => {
     )
     expiredTokenErr.code = 'auth/id-token-expired'
     const mockFirebaseUser = createMockFirebaseUserAdminSDK()
+    const admin = getFirebaseAdminApp()
     admin.auth().verifyIdToken.mockImplementation(async (token) => {
       if (token === 'some-token') {
         throw expiredTokenErr
@@ -104,6 +109,7 @@ describe('verifyIdToken', () => {
     )
     expiredTokenErr.code = 'auth/id-token-expired'
     const mockFirebaseUser = createMockFirebaseUserAdminSDK()
+    const admin = getFirebaseAdminApp()
     admin.auth().verifyIdToken.mockImplementation(async (token) => {
       if (token === 'some-token') {
         throw expiredTokenErr
@@ -126,6 +132,7 @@ describe('verifyIdToken', () => {
     )
     expiredTokenErr.code = 'auth/id-token-expired'
     const mockFirebaseUser = createMockFirebaseUserAdminSDK()
+    const admin = getFirebaseAdminApp()
     admin.auth().verifyIdToken.mockImplementation(async (token) => {
       if (token === 'some-token') {
         throw expiredTokenErr
@@ -160,6 +167,7 @@ describe('verifyIdToken', () => {
     )
     expiredTokenErr.code = 'auth/id-token-expired'
     const mockFirebaseUser = createMockFirebaseUserAdminSDK()
+    const admin = getFirebaseAdminApp()
     admin.auth().verifyIdToken.mockImplementation(async (token) => {
       if (token === 'some-token') {
         throw expiredTokenErr
@@ -194,6 +202,7 @@ describe('verifyIdToken', () => {
     // Mock that the original token is expired but a new token works.
     const otherErr = new Error('The Firebase ID token has been revoked.')
     otherErr.code = 'auth/id-token-revoked' // a different error
+    const admin = getFirebaseAdminApp()
     admin.auth().verifyIdToken.mockImplementation(async () => {
       throw otherErr
     })
@@ -211,6 +220,7 @@ describe('verifyIdToken', () => {
       'The provided Firebase ID token is expired.'
     )
     expiredTokenErr.code = 'auth/id-token-expired'
+    const admin = getFirebaseAdminApp()
     admin.auth().verifyIdToken.mockImplementation(async () => {
       throw expiredTokenErr
     })
@@ -224,6 +234,7 @@ describe('getCustomIdAndRefreshTokens', () => {
   it("passes the Firebase user's ID (from verifyIdToken) to createCustomToken", async () => {
     const { getCustomIdAndRefreshTokens } = require('src/firebaseAdmin')
     const mockFirebaseUser = createMockFirebaseUserAdminSDK()
+    const admin = getFirebaseAdminApp()
     admin.auth().verifyIdToken.mockResolvedValue(mockFirebaseUser)
     admin.auth().createCustomToken.mockResolvedValue('my-custom-token')
     await getCustomIdAndRefreshTokens('some-token')
@@ -247,6 +258,7 @@ describe('getCustomIdAndRefreshTokens', () => {
     })
 
     const mockFirebaseUser = createMockFirebaseUserAdminSDK()
+    const admin = getFirebaseAdminApp()
     admin.auth().verifyIdToken.mockResolvedValue(mockFirebaseUser)
     admin.auth().createCustomToken.mockResolvedValue('my-custom-token')
     await getCustomIdAndRefreshTokens('some-token')
@@ -260,6 +272,7 @@ describe('getCustomIdAndRefreshTokens', () => {
   it('uses the expected fetch options when calling to get a custom token', async () => {
     const { getCustomIdAndRefreshTokens } = require('src/firebaseAdmin')
     const mockFirebaseUser = createMockFirebaseUserAdminSDK()
+    const admin = getFirebaseAdminApp()
     admin.auth().verifyIdToken.mockResolvedValue(mockFirebaseUser)
     admin.auth().createCustomToken.mockResolvedValue('my-custom-token')
     await getCustomIdAndRefreshTokens('some-token')
@@ -287,6 +300,7 @@ describe('getCustomIdAndRefreshTokens', () => {
     })
 
     const mockFirebaseUser = createMockFirebaseUserAdminSDK()
+    const admin = getFirebaseAdminApp()
     admin.auth().verifyIdToken.mockResolvedValue(mockFirebaseUser)
     admin.auth().createCustomToken.mockResolvedValue('my-custom-token')
     const response = await getCustomIdAndRefreshTokens('some-token')
@@ -314,6 +328,7 @@ describe('getCustomIdAndRefreshTokens', () => {
     const expectedAuthUser = createAuthUser({
       firebaseUserAdminSDK: mockFirebaseUser,
     })
+    const admin = getFirebaseAdminApp()
     admin.auth().verifyIdToken.mockResolvedValue(mockFirebaseUser)
     admin.auth().createCustomToken.mockResolvedValue('my-custom-token')
     const response = await getCustomIdAndRefreshTokens('some-token')
@@ -341,6 +356,7 @@ describe('getCustomIdAndRefreshTokens', () => {
     })
 
     const mockFirebaseUser = createMockFirebaseUserAdminSDK()
+    const admin = getFirebaseAdminApp()
     admin.auth().verifyIdToken.mockResolvedValue(mockFirebaseUser)
     admin.auth().createCustomToken.mockResolvedValue('my-custom-token')
     await expect(getCustomIdAndRefreshTokens('some-token')).rejects.toEqual(

--- a/src/__tests__/index.server.test.js
+++ b/src/__tests__/index.server.test.js
@@ -23,11 +23,13 @@ describe('index.server.js: init', () => {
     expect(indexServer.init).toEqual(expect.any(Function))
   })
 
-  it('calls initFirebaseAdminSDK', () => {
+  // We only initialize the Firebase admin SDK as it's needed. See:
+  // https://github.com/gladly-team/next-firebase-auth/issues/70
+  it('does not call initFirebaseAdminSDK', () => {
     expect.assertions(1)
     const indexServer = require('src/index.server').default
     indexServer.init({ fake: 'config' })
-    expect(initFirebaseAdminSDK).toHaveBeenCalled()
+    expect(initFirebaseAdminSDK).not.toHaveBeenCalled()
   })
 
   it('calls index.js (client) init', () => {

--- a/src/__tests__/initFirebaseAdminSDK.test.js
+++ b/src/__tests__/initFirebaseAdminSDK.test.js
@@ -36,6 +36,13 @@ describe('initFirebaseAdminSDK', () => {
     })
   })
 
+  it('returns the admin app', () => {
+    expect.assertions(1)
+    const initFirebaseAdminSDK = require('src/initFirebaseAdminSDK').default
+    const response = initFirebaseAdminSDK()
+    expect(response).toEqual(admin)
+  })
+
   it('does not call admin.initializeApp if Firebase already has an initialized app', () => {
     expect.assertions(1)
     admin.apps = [{ some: 'app' }]

--- a/src/firebaseAdmin.js
+++ b/src/firebaseAdmin.js
@@ -1,4 +1,4 @@
-import * as admin from 'firebase-admin'
+import getFirebaseAdminApp from 'src/initFirebaseAdminSDK'
 import createAuthUser from 'src/createAuthUser'
 import { getConfig } from 'src/config'
 
@@ -48,6 +48,7 @@ const refreshExpiredIdToken = async (refreshToken) => {
 export const verifyIdToken = async (token, refreshToken = null) => {
   let firebaseUser
   let newToken = token
+  const admin = getFirebaseAdminApp()
   try {
     firebaseUser = await admin.auth().verifyIdToken(token)
   } catch (e) {
@@ -81,6 +82,7 @@ export const verifyIdToken = async (token, refreshToken = null) => {
  */
 export const getCustomIdAndRefreshTokens = async (token) => {
   const AuthUser = await verifyIdToken(token)
+  const admin = getFirebaseAdminApp()
 
   // It's important that we pass the same user ID here, otherwise
   // Firebase will create a new user.

--- a/src/index.server.js
+++ b/src/index.server.js
@@ -5,15 +5,12 @@ import index from 'src/index'
 import setAuthCookies from 'src/setAuthCookies'
 import unsetAuthCookies from 'src/unsetAuthCookies'
 import withAuthUserTokenSSRModule from 'src/withAuthUserTokenSSR'
-import initFirebaseAdminSDK from 'src/initFirebaseAdminSDK'
 import { verifyIdToken } from 'src/firebaseAdmin'
 
 const initServer = (config) => {
   const clientInit = index.init(config)
-
-  // On the server only, initialize the Firebase admin SDK.
-  initFirebaseAdminSDK()
-
+  // We only initialize the Firebase admin SDK as it's needed. See:
+  // https://github.com/gladly-team/next-firebase-auth/issues/70
   return clientInit
 }
 

--- a/src/initFirebaseAdminSDK.js
+++ b/src/initFirebaseAdminSDK.js
@@ -16,6 +16,7 @@ const initFirebaseAdminSDK = () => {
       }),
     })
   }
+  return admin
 }
 
 export default initFirebaseAdminSDK


### PR DESCRIPTION
Closes #70 

Breaking in the case that the developer has relied on this package to validate that the `firebaseAdminInitConfig` setting is defined at build time.