### PR TITLE
Send Refresh Token Request to the Emulator

### DIFF
--- a/src/firebaseAdmin.js
+++ b/src/firebaseAdmin.js
@@ -90,7 +90,11 @@ export const getCustomIdAndRefreshTokens = async (token) => {
 
   // https://firebase.google.com/docs/reference/rest/auth/#section-verify-custom-token
   const firebasePublicAPIKey = getFirebasePublicAPIKey()
-  const refreshTokenEndpoint = `https://identitytoolkit.googleapis.com/v1/accounts:signInWithCustomToken?key=${firebasePublicAPIKey}`
+  
+  // If the FIREBASE_AUTH_EMULATOR_HOST variable is set, send the token request to the emulator
+  const tokenPrefix = process.env.FIREBASE_AUTH_EMULATOR_HOST ? `http://${process.env.FIREBASE_AUTH_EMULATOR_HOST}/` : 'https://'
+  
+  const refreshTokenEndpoint = `${tokenPrefix}identitytoolkit.googleapis.com/v1/accounts:signInWithCustomToken?key=${firebasePublicAPIKey}`
 
   const refreshTokenResponse = await fetch(refreshTokenEndpoint, {
     method: 'POST',

--- a/src/firebaseAdmin.js
+++ b/src/firebaseAdmin.js
@@ -22,7 +22,11 @@ const refreshExpiredIdToken = async (refreshToken) => {
 
   // https://firebase.google.com/docs/reference/rest/auth/#section-refresh-token
   const firebasePublicAPIKey = getFirebasePublicAPIKey()
-  const endpoint = `https://securetoken.googleapis.com/v1/token?key=${firebasePublicAPIKey}`
+  
+   // If the FIREBASE_AUTH_EMULATOR_HOST variable is set, send the token request to the emulator
+  const tokenPrefix = process.env.FIREBASE_AUTH_EMULATOR_HOST ? `http://${process.env.FIREBASE_AUTH_EMULATOR_HOST}/` : 'https://'
+
+  const endpoint = `${tokenPrefix}securetoken.googleapis.com/v1/token?key=${firebasePublicAPIKey}`
 
   const response = await fetch(endpoint, {
     method: 'POST',


### PR DESCRIPTION
Confirms this works in dev when the auth emulator is initialized prior to calling the package's init() method.

If the FIREBASE_AUTH_EMULATOR_HOST variable is sent, the server will send the request to the emulator and not to google.