### PR TITLE
Support Firebase auth emulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ const initAuth = () => {
     appPageURL: '/',
     loginAPIEndpoint: '/api/login', // required
     logoutAPIEndpoint: '/api/logout', // required
+    firebaseAuthEmulatorHost: 'localhost:9099',
     // Required in most cases.
     firebaseAdminInitConfig: {
       credential: {
@@ -101,7 +102,7 @@ export default initAuth
 
 ```
 
-Set the private environment variables `FIREBASE_PRIVATE_KEY`, `COOKIE_SECRET_CURRENT`, and `COOKIE_SECRET_PREVIOUS` in `.env.local`. See [the config](#config) documentation for details.
+Set the private environment variables `FIREBASE_PRIVATE_KEY`, `COOKIE_SECRET_CURRENT`, and `COOKIE_SECRET_PREVIOUS` in `.env.local`. See [the config](#config) documentation for details. If you have enabled [the Firebase Authentication Emulator](#https://firebase.google.com/docs/emulator-suite/connect_auth), you will also need to set the `FIREBASE_AUTH_EMULATOR_HOST` environment variable.
 
 Initialize `next-firebase-auth` in `_app.js`:
 ```js
@@ -363,6 +364,10 @@ If this callback is specified, user is responsible for:
 3. Ensuring it allows the request to set cookies.
 
 Cannot be set with `loginAPIEndpoint` or `logoutAPIEndpoint`.
+
+**firebaseAuthEmulatorHost**: The host and port for the local [Firebase Auth Emulator](https://firebase.google.com/docs/emulator-suite/connect_auth#admin_sdks). If this value is set, the auth emulator will be initialized with the provided host and port. 
+
+Must be exactly the same as the value of the `FIREBASE_AUTH_EMULATOR_HOST` environment variable, e.g., `localhost:9099`. 
 
 #### **firebaseAdminInitConfig**
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -54,6 +54,7 @@ interface InitConfig {
     };
     databaseURL: string;
   };
+  firebaseAuthEmulatorHost?: string;
   firebaseClientInitConfig: {
     apiKey: string;
     authDomain?: string;

--- a/src/__tests__/config.test.js
+++ b/src/__tests__/config.test.js
@@ -2,14 +2,20 @@ import createMockConfig from 'src/testHelpers/createMockConfig'
 
 jest.mock('src/isClientSide')
 
+// stash and restore the system env vars
+let env = null
+
 beforeEach(() => {
   // Default to client side context.
   const isClientSide = require('src/isClientSide').default
   isClientSide.mockReturnValue(true)
+  env = { ...process.env }
 })
 
 afterEach(() => {
   jest.resetModules()
+  process.env = env
+  env = null
 })
 
 describe('config', () => {
@@ -457,12 +463,6 @@ it('[server-side] throws if config.firebaseAuthEmulatorHost is set, but not the 
 })
 
 it('[server-side] throws if the FIREBASE_AUTH_EMULATOR_HOST env var differs from the one set in the config', () => {
-  // since we are adding to process.env, take a clone and reset after each test to prevent a memory leak
-  const env = { ...process.env }
-  afterEach(() => {
-    process.env = env
-  })
-
   expect.assertions(1)
   const isClientSide = require('src/isClientSide').default
   isClientSide.mockReturnValue(false)
@@ -481,12 +481,6 @@ it('[server-side] throws if the FIREBASE_AUTH_EMULATOR_HOST env var differs from
 })
 
 it('[server-side] should not throw if the FIREBASE_AUTH_EMULATOR_HOST env variable is set and matches the one set in the config', () => {
-  // since we are adding to process.env, take a clone and reset after each test to prevent a memory leak
-  const env = { ...process.env }
-  afterEach(() => {
-    process.env = env
-  })
-
   expect.assertions(1)
   const isClientSide = require('src/isClientSide').default
   isClientSide.mockReturnValue(false)

--- a/src/__tests__/config.test.js
+++ b/src/__tests__/config.test.js
@@ -424,6 +424,40 @@ describe('config', () => {
   })
 })
 
+it('should throw if the config.firebaseAuthEmulator has a http or https prefix', () => {
+  expect.assertions(1)
+  const { setConfig } = require('src/config')
+  const mockConfigDefault = createMockConfig()
+  const mockConfig = {
+    ...mockConfigDefault,
+    firebaseAuthEmulatorHost: 'http://localhost:9099',
+  }
+  expect(() => {
+    setConfig(mockConfig)
+  }).toThrow(
+    'Invalid next-firebase-auth options: The firebaseAuthEmulatorHost should be set without a prefix (e.g., localhost:9099)'
+  )
+})
+it('should throw if the config.firebaseAuthEmulatorHost is set in production', () => {
+  const env = { ...process.env }
+  afterEach(() => {
+    process.env = env
+  })
+  expect.assertions(1)
+  process.env.NODE_ENV = 'production'
+  const { setConfig } = require('src/config')
+  const mockConfigDefault = createMockConfig()
+  const mockConfig = {
+    ...mockConfigDefault,
+    firebaseAuthEmulatorHost: 'localhost:9099',
+  }
+  expect(() => {
+    setConfig(mockConfig)
+  }).toThrow(
+    'The firebaseAuthEmulatorHost should only be used during testing and development'
+  )
+})
+
 it('[server-side] throws if config.firebaseAuthEmulatorHost is set, but not the FIREBASE_AUTH_EMULATOR_HOST env var', () => {
   expect.assertions(1)
   const isClientSide = require('src/isClientSide').default
@@ -432,7 +466,7 @@ it('[server-side] throws if config.firebaseAuthEmulatorHost is set, but not the 
   const mockConfigDefault = createMockConfig()
   const mockConfig = {
     ...mockConfigDefault,
-    firebaseAuthEmulatorHost: 'http://localhost:9099',
+    firebaseAuthEmulatorHost: 'localhost:9099',
   }
   expect(() => {
     setConfig(mockConfig)
@@ -455,9 +489,9 @@ it('[server-side] throws if the FIREBASE_AUTH_EMULATOR_HOST env var differs from
   const mockConfigDefault = createMockConfig()
   const mockConfig = {
     ...mockConfigDefault,
-    firebaseAuthEmulatorHost: 'http://localhost:9099',
+    firebaseAuthEmulatorHost: 'localhost:9099',
   }
-  process.env.FIREBASE_AUTH_EMULATOR_HOST = 'http://localhost:8088'
+  process.env.FIREBASE_AUTH_EMULATOR_HOST = 'localhost:8088'
   expect(() => {
     setConfig(mockConfig)
   }).toThrow(
@@ -479,12 +513,10 @@ it('[server-side] should not throw if the FIREBASE_AUTH_EMULATOR_HOST env variab
   const mockConfigDefault = createMockConfig()
   const mockConfig = {
     ...mockConfigDefault,
-    firebaseAuthEmulatorHost: 'http://localhost:9099',
+    firebaseAuthEmulatorHost: 'localhost:9099',
   }
-  process.env.FIREBASE_AUTH_EMULATOR_HOST = 'http://localhost:9099'
+  process.env.FIREBASE_AUTH_EMULATOR_HOST = 'localhost:9099'
   expect(() => {
     setConfig(mockConfig)
-  }).not.toThrow(
-    'The "FIREBASE_AUTH_EMULATOR_HOST" environment variable should be the same as the host set in the config'
-  )
+  }).not.toThrow()
 })

--- a/src/__tests__/config.test.js
+++ b/src/__tests__/config.test.js
@@ -423,3 +423,68 @@ describe('config', () => {
     )
   })
 })
+
+it('[server-side] throws if config.firebaseAuthEmulatorHost is set, but not the FIREBASE_AUTH_EMULATOR_HOST env var', () => {
+  expect.assertions(1)
+  const isClientSide = require('src/isClientSide').default
+  isClientSide.mockReturnValue(false)
+  const { setConfig } = require('src/config')
+  const mockConfigDefault = createMockConfig()
+  const mockConfig = {
+    ...mockConfigDefault,
+    firebaseAuthEmulatorHost: 'http://localhost:9099',
+  }
+  expect(() => {
+    setConfig(mockConfig)
+  }).toThrow(
+    'The "FIREBASE_AUTH_EMULATOR_HOST" environment variable should be set if you are using the "firebaseAuthEmulatorHost" option'
+  )
+})
+
+it('[server-side] throws if the FIREBASE_AUTH_EMULATOR_HOST env var differs from the one set in the config', () => {
+  // since we are adding to process.env, take a clone and reset after each test to prevent a memory leak
+  const env = { ...process.env }
+  afterEach(() => {
+    process.env = env
+  })
+
+  expect.assertions(1)
+  const isClientSide = require('src/isClientSide').default
+  isClientSide.mockReturnValue(false)
+  const { setConfig } = require('src/config')
+  const mockConfigDefault = createMockConfig()
+  const mockConfig = {
+    ...mockConfigDefault,
+    firebaseAuthEmulatorHost: 'http://localhost:9099',
+  }
+  process.env.FIREBASE_AUTH_EMULATOR_HOST = 'http://localhost:8088'
+  expect(() => {
+    setConfig(mockConfig)
+  }).toThrow(
+    'The "FIREBASE_AUTH_EMULATOR_HOST" environment variable should be the same as the host set in the config'
+  )
+})
+
+it('[server-side] should not throw if the FIREBASE_AUTH_EMULATOR_HOST env variable is set and matches the one set in the config', () => {
+  // since we are adding to process.env, take a clone and reset after each test to prevent a memory leak
+  const env = { ...process.env }
+  afterEach(() => {
+    process.env = env
+  })
+
+  expect.assertions(1)
+  const isClientSide = require('src/isClientSide').default
+  isClientSide.mockReturnValue(false)
+  const { setConfig } = require('src/config')
+  const mockConfigDefault = createMockConfig()
+  const mockConfig = {
+    ...mockConfigDefault,
+    firebaseAuthEmulatorHost: 'http://localhost:9099',
+  }
+  process.env.FIREBASE_AUTH_EMULATOR_HOST = 'http://localhost:9099'
+  expect(() => {
+    setConfig(mockConfig)
+  }).not.toThrow(
+    'The "FIREBASE_AUTH_EMULATOR_HOST" environment variable should be the same as the host set in the config'
+  )
+})

--- a/src/__tests__/config.test.js
+++ b/src/__tests__/config.test.js
@@ -438,25 +438,6 @@ it('should throw if the config.firebaseAuthEmulator has a http or https prefix',
     'Invalid next-firebase-auth options: The firebaseAuthEmulatorHost should be set without a prefix (e.g., localhost:9099)'
   )
 })
-it('should throw if the config.firebaseAuthEmulatorHost is set in production', () => {
-  const env = { ...process.env }
-  afterEach(() => {
-    process.env = env
-  })
-  expect.assertions(1)
-  process.env.NODE_ENV = 'production'
-  const { setConfig } = require('src/config')
-  const mockConfigDefault = createMockConfig()
-  const mockConfig = {
-    ...mockConfigDefault,
-    firebaseAuthEmulatorHost: 'localhost:9099',
-  }
-  expect(() => {
-    setConfig(mockConfig)
-  }).toThrow(
-    'The firebaseAuthEmulatorHost should only be used during testing and development'
-  )
-})
 
 it('[server-side] throws if config.firebaseAuthEmulatorHost is set, but not the FIREBASE_AUTH_EMULATOR_HOST env var', () => {
   expect.assertions(1)

--- a/src/__tests__/firebaseAdmin.test.js
+++ b/src/__tests__/firebaseAdmin.test.js
@@ -243,7 +243,7 @@ describe('getCustomIdAndRefreshTokens', () => {
     )
   })
 
-  it('calls the expected endpoint to get a custom token, including the public Firebase API key as a URL parameter', async () => {
+  it('calls the public google endpoint if the firebaseAuthEmulatorHost is not set to get a custom token, including the public Firebase API key as a URL parameter', async () => {
     const { getCustomIdAndRefreshTokens } = require('src/firebaseAdmin')
 
     // Set the Firebase API key.
@@ -267,6 +267,38 @@ describe('getCustomIdAndRefreshTokens', () => {
     expect(endpoint).toEqual(
       `${googleCustomTokenEndpoint}?key=${expectedAPIKey}`
     )
+  })
+
+  it('calls the auth emulator endpoint if the firebaseAuthEmulatorHost is set to get a custom token, including the public Firebase API key as a URL parameter', async () => {
+    const env = { ...process.env }
+    afterEach(() => {
+      process.env = env
+    })
+    process.env.FIREBASE_AUTH_EMULATOR_HOST = 'localhost:9099'
+    const { getCustomIdAndRefreshTokens } = require('src/firebaseAdmin')
+
+    // Set the Firebase API key.
+    const expectedAPIKey = 'my-api-key!'
+    const mockConfig = createMockConfig()
+    setConfig({
+      ...mockConfig,
+      firebaseClientInitConfig: {
+        ...mockConfig.firebaseClientInitConfig,
+        apiKey: expectedAPIKey,
+      },
+      firebaseAuthEmulatorHost: 'localhost:9099',
+    })
+
+    const authEmulatorEndpoint =
+      'http://localhost:9099/identitytoolkit.googleapis.com/v1/accounts:signInWithCustomToken'
+    const mockFirebaseUser = createMockFirebaseUserAdminSDK()
+    const admin = getFirebaseAdminApp()
+    admin.auth().verifyIdToken.mockResolvedValue(mockFirebaseUser)
+    admin.auth().createCustomToken.mockResolvedValue('my-custom-token')
+    await getCustomIdAndRefreshTokens('some-token')
+
+    const endpoint = global.fetch.mock.calls[0][0]
+    expect(endpoint).toEqual(`${authEmulatorEndpoint}?key=${expectedAPIKey}`)
   })
 
   it('uses the expected fetch options when calling to get a custom token', async () => {

--- a/src/__tests__/firebaseAdmin.test.js
+++ b/src/__tests__/firebaseAdmin.test.js
@@ -9,6 +9,9 @@ import getFirebaseAdminApp from 'src/initFirebaseAdminSDK'
 // the underyling Firebase admin app.
 jest.mock('firebase-admin')
 
+// stash and restore the system env vars
+let env = null
+
 beforeEach(() => {
   // `fetch` is polyfilled by Next.js.
   global.fetch = jest.fn(() => Promise.resolve(createMockFetchResponse()))
@@ -21,6 +24,12 @@ beforeEach(() => {
       apiKey: 'some-key',
     },
   })
+  env = { ...process.env }
+})
+
+afterEach(() => {
+  process.env = env
+  env = null
 })
 
 const googleRefreshTokenEndpoint = 'https://securetoken.googleapis.com/v1/token'
@@ -270,10 +279,6 @@ describe('getCustomIdAndRefreshTokens', () => {
   })
 
   it('calls the auth emulator endpoint if the firebaseAuthEmulatorHost is set to get a custom token, including the public Firebase API key as a URL parameter', async () => {
-    const env = { ...process.env }
-    afterEach(() => {
-      process.env = env
-    })
     process.env.FIREBASE_AUTH_EMULATOR_HOST = 'localhost:9099'
     const { getCustomIdAndRefreshTokens } = require('src/firebaseAdmin')
 

--- a/src/__tests__/initFirebaseClientSDK.test.js
+++ b/src/__tests__/initFirebaseClientSDK.test.js
@@ -66,4 +66,37 @@ describe('initFirebaseClientSDK', () => {
       initFirebaseClientSDK()
     }).not.toThrow()
   })
+
+  it('initializes the client-side auth emulator if config.firebaseAuthEmulatorHost is set', () => {
+    expect.assertions(1)
+    const mockConfig = createMockConfig()
+    setConfig({
+      ...mockConfig,
+      firebaseAuthEmulatorHost: 'http://localhost:9099',
+    })
+    firebase.apps = [{ some: 'app' }]
+    const initFirebaseClientSDK = require('src/initFirebaseClientSDK').default
+
+    const useEmulator = jest.fn()
+    firebase.auth.mockImplementation(() => ({
+      useEmulator,
+    }))
+
+    initFirebaseClientSDK()
+    expect(useEmulator).toHaveBeenCalledWith('http://localhost:9099')
+  })
+
+  it('does not initialize the client-side auth emulator if config.firebaseAuthEmulatorHost is not set', () => {
+    expect.assertions(1)
+    firebase.apps = [{ some: 'app' }]
+    const initFirebaseClientSDK = require('src/initFirebaseClientSDK').default
+
+    const useEmulator = jest.fn()
+    firebase.auth.mockImplementation(() => ({
+      useEmulator,
+    }))
+
+    initFirebaseClientSDK()
+    expect(useEmulator).not.toHaveBeenCalled()
+  })
 })

--- a/src/__tests__/initFirebaseClientSDK.test.js
+++ b/src/__tests__/initFirebaseClientSDK.test.js
@@ -72,7 +72,7 @@ describe('initFirebaseClientSDK', () => {
     const mockConfig = createMockConfig()
     setConfig({
       ...mockConfig,
-      firebaseAuthEmulatorHost: 'http://localhost:9099',
+      firebaseAuthEmulatorHost: 'localhost:9099',
     })
     firebase.apps = [{ some: 'app' }]
     const initFirebaseClientSDK = require('src/initFirebaseClientSDK').default

--- a/src/config.js
+++ b/src/config.js
@@ -94,15 +94,6 @@ const validateConfig = (mergedConfig) => {
     )
   }
 
-  // Make sure the emulator isn't set for a production environment
-  if (
-    mergedConfig.firebaseAuthEmulatorHost &&
-    process.env.NODE_ENV === 'production'
-  ) {
-    errorMessages.push(
-      'The firebaseAuthEmulatorHost should only be used during testing and development'
-    )
-  }
   // make sure the host address is set correctly.
   if (
     mergedConfig.firebaseAuthEmulatorHost &&

--- a/src/config.js
+++ b/src/config.js
@@ -34,6 +34,12 @@ const defaultConfig = {
   // required, but other options are optional if the app
   // initializes the admin SDK manually.
   firebaseClientInitConfig: undefined,
+  // Optional object: the firebase auth emulator host address
+  // on the user's machine. Should default to 'http://localhost:9099'
+  // see https://firebase.google.com/docs/emulator-suite/connect_auth
+  // user will still have to set the FIREBASE_AUTH_EMULATOR_HOST variable
+  // for the server-side admin functions
+  firebaseAuthEmulatorHost: undefined,
   cookies: {
     // Required string. The base name for the auth cookies.
     name: undefined,
@@ -125,7 +131,22 @@ const validateConfig = (mergedConfig) => {
         'The "cookies.keys" setting must be set if "cookies.signed" is true.'
       )
     }
-
+    // check if the AUTH_EMULATOR_HOST_VARIABLE is set if the user has
+    // set the config to use the authEmultor
+    if (mergedConfig.firebaseAuthEmulatorHost) {
+      if (!process.env.FIREBASE_AUTH_EMULATOR_HOST) {
+        errorMessages.push(
+          'The "FIREBASE_AUTH_EMULATOR_HOST" environment variable should be set if you are using the "firebaseAuthEmulatorHost" option'
+        )
+      } else if (
+        process.env.FIREBASE_AUTH_EMULATOR_HOST !==
+        mergedConfig.firebaseAuthEmulatorHost
+      ) {
+        errorMessages.push(
+          'The "FIREBASE_AUTH_EMULATOR_HOST" environment variable should be the same as the host set in the config'
+        )
+      }
+    }
     // Limit the max cookie age to two weeks for security. This matches
     // Firebase's limit for user identity cookies:
     // https://firebase.google.com/docs/auth/admin/manage-cookies

--- a/src/config.js
+++ b/src/config.js
@@ -35,10 +35,9 @@ const defaultConfig = {
   // initializes the admin SDK manually.
   firebaseClientInitConfig: undefined,
   // Optional object: the firebase auth emulator host address
-  // on the user's machine. Should default to 'http://localhost:9099'
+  // on the user's machine. Should be set to 'localhost:9099' in order
+  // to match the FIREBASE_AUTH_EMULATOR_HOST variable on the server
   // see https://firebase.google.com/docs/emulator-suite/connect_auth
-  // user will still have to set the FIREBASE_AUTH_EMULATOR_HOST variable
-  // for the server-side admin functions
   firebaseAuthEmulatorHost: undefined,
   cookies: {
     // Required string. The base name for the auth cookies.

--- a/src/config.js
+++ b/src/config.js
@@ -95,6 +95,25 @@ const validateConfig = (mergedConfig) => {
     )
   }
 
+  // Make sure the emulator isn't set for a production environment
+  if (
+    mergedConfig.firebaseAuthEmulatorHost &&
+    process.env.NODE_ENV === 'production'
+  ) {
+    errorMessages.push(
+      'The firebaseAuthEmulatorHost should only be used during testing and development'
+    )
+  }
+  // make sure the host address is set correctly.
+  if (
+    mergedConfig.firebaseAuthEmulatorHost &&
+    mergedConfig.firebaseAuthEmulatorHost.startsWith('http')
+  ) {
+    errorMessages.push(
+      'The firebaseAuthEmulatorHost should be set without a prefix (e.g., localhost:9099)'
+    )
+  }
+
   // We consider cookie keys undefined if the keys are an empty string,
   // empty array, or array of only undefined values.
   const { keys } = mergedConfig.cookies

--- a/src/firebaseAdmin.js
+++ b/src/firebaseAdmin.js
@@ -6,9 +6,10 @@ import { getConfig } from 'src/config'
 const FIREBASE_ERROR_TOKEN_EXPIRED = 'auth/id-token-expired'
 
 // If the FIREBASE_AUTH_EMULATOR_HOST variable is set, send the token request to the emulator
-const TOKEN_URL_PREFIX = process.env.FIREBASE_AUTH_EMULATOR_HOST
-  ? `http://${process.env.FIREBASE_AUTH_EMULATOR_HOST}/`
-  : 'https://'
+const getTokenPrefix = () =>
+  process.env.FIREBASE_AUTH_EMULATOR_HOST
+    ? `http://${process.env.FIREBASE_AUTH_EMULATOR_HOST}/`
+    : 'https://'
 
 const getFirebasePublicAPIKey = () => {
   const config = getConfig()
@@ -28,7 +29,7 @@ const refreshExpiredIdToken = async (refreshToken) => {
   // https://firebase.google.com/docs/reference/rest/auth/#section-refresh-token
   const firebasePublicAPIKey = getFirebasePublicAPIKey()
 
-  const endpoint = `${TOKEN_URL_PREFIX}securetoken.googleapis.com/v1/token?key=${firebasePublicAPIKey}`
+  const endpoint = `${getTokenPrefix()}securetoken.googleapis.com/v1/token?key=${firebasePublicAPIKey}`
 
   const response = await fetch(endpoint, {
     method: 'POST',
@@ -97,7 +98,7 @@ export const getCustomIdAndRefreshTokens = async (token) => {
   // https://firebase.google.com/docs/reference/rest/auth/#section-verify-custom-token
   const firebasePublicAPIKey = getFirebasePublicAPIKey()
 
-  const refreshTokenEndpoint = `${TOKEN_URL_PREFIX}identitytoolkit.googleapis.com/v1/accounts:signInWithCustomToken?key=${firebasePublicAPIKey}`
+  const refreshTokenEndpoint = `${getTokenPrefix()}identitytoolkit.googleapis.com/v1/accounts:signInWithCustomToken?key=${firebasePublicAPIKey}`
 
   const refreshTokenResponse = await fetch(refreshTokenEndpoint, {
     method: 'POST',

--- a/src/firebaseAdmin.js
+++ b/src/firebaseAdmin.js
@@ -5,6 +5,11 @@ import { getConfig } from 'src/config'
 // https://firebase.google.com/docs/auth/admin/errors
 const FIREBASE_ERROR_TOKEN_EXPIRED = 'auth/id-token-expired'
 
+// If the FIREBASE_AUTH_EMULATOR_HOST variable is set, send the token request to the emulator
+const TOKEN_URL_PREFIX = process.env.FIREBASE_AUTH_EMULATOR_HOST
+  ? `http://${process.env.FIREBASE_AUTH_EMULATOR_HOST}/`
+  : 'https://'
+
 const getFirebasePublicAPIKey = () => {
   const config = getConfig()
   return config.firebaseClientInitConfig.apiKey
@@ -22,7 +27,8 @@ const refreshExpiredIdToken = async (refreshToken) => {
 
   // https://firebase.google.com/docs/reference/rest/auth/#section-refresh-token
   const firebasePublicAPIKey = getFirebasePublicAPIKey()
-  const endpoint = `https://securetoken.googleapis.com/v1/token?key=${firebasePublicAPIKey}`
+
+  const endpoint = `${TOKEN_URL_PREFIX}securetoken.googleapis.com/v1/token?key=${firebasePublicAPIKey}`
 
   const response = await fetch(endpoint, {
     method: 'POST',
@@ -90,7 +96,8 @@ export const getCustomIdAndRefreshTokens = async (token) => {
 
   // https://firebase.google.com/docs/reference/rest/auth/#section-verify-custom-token
   const firebasePublicAPIKey = getFirebasePublicAPIKey()
-  const refreshTokenEndpoint = `https://identitytoolkit.googleapis.com/v1/accounts:signInWithCustomToken?key=${firebasePublicAPIKey}`
+
+  const refreshTokenEndpoint = `${TOKEN_URL_PREFIX}identitytoolkit.googleapis.com/v1/accounts:signInWithCustomToken?key=${firebasePublicAPIKey}`
 
   const refreshTokenResponse = await fetch(refreshTokenEndpoint, {
     method: 'POST',

--- a/src/initFirebaseClientSDK.js
+++ b/src/initFirebaseClientSDK.js
@@ -14,6 +14,6 @@ export default function initFirebaseClientSDK() {
   }
   // If the user has provided the firebaseAuthEmulatorHost address, set the emulator
   if (firebaseAuthEmulatorHost) {
-    firebase.auth().useEmulator(firebaseAuthEmulatorHost)
+    firebase.auth().useEmulator(`http://${firebaseAuthEmulatorHost}`)
   }
 }

--- a/src/initFirebaseClientSDK.js
+++ b/src/initFirebaseClientSDK.js
@@ -3,13 +3,17 @@ import 'firebase/auth'
 import { getConfig } from 'src/config'
 
 export default function initFirebaseClientSDK() {
+  const { firebaseClientInitConfig, firebaseAuthEmulatorHost } = getConfig()
   if (!firebase.apps.length) {
-    const { firebaseClientInitConfig } = getConfig()
     if (!firebaseClientInitConfig) {
       throw new Error(
         'If not initializing the Firebase JS SDK elsewhere, you must provide "firebaseClientInitConfig" to next-firebase-auth.'
       )
     }
     firebase.initializeApp(firebaseClientInitConfig)
+  }
+  // If the user has provided the firebaseAuthEmulatorHost address, set the emulator
+  if (firebaseAuthEmulatorHost) {
+    firebase.auth().useEmulator(firebaseAuthEmulatorHost)
   }
 }


### PR DESCRIPTION
Add Feature from #63 #59 

When using the Auth Emulator, all requests for google tokens should be router to the emulator address and not the actual google endpoint, otherwise the tokens won't match.

The change now checks if the FIREBASE_AUTH_EMULATOR_HOST environment variable is provided, and if so, prefixes the request with the unsecured host rather than the secured https call to google.