### PR TITLE
Get Firebase Admin Server Side

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ export default withAuthUser()(Demo)
 * [unsetAuthCookies](#unsetauthcookiesreq-res)
 * [verifyIdToken](#verifyidtokentoken--promiseauthuser)
 * [AuthAction](#authaction)
+* [getFirebaseAdmin](#getFirebaseAdmin)
 
 -----
 #### `init(config)`
@@ -343,6 +344,43 @@ Verifies a Firebase ID token and resolves to an [`AuthUser`](#authuser) instance
 #### `AuthAction`
 
 An object that defines rendering/redirecting options for `withAuthUser` and `withAuthUserTokenSSR`. See [AuthAction](#authaction-1).
+
+#### `getFirebaseAdmin() => app.App`
+
+A function that returns the configured Firebase Admin application.
+
+This can only be called from the server side; will throw an error is called from client side.
+
+For example:
+````jsx
+...
+import { getFirebaseAdmin } from 'next-firebase-auth'
+...
+
+const Artist = ({artists}) => {
+  return (
+    <ul>
+      {artists.map((artist) => <li>{artist.name}</li>)} 
+    </ul>
+  )
+}
+export async function getServerSideProps({ params: { id } }) {
+     const db = getFirebaseAdmin().firestore()
+     const doc = await db.collection('artists').get()
+
+     return {
+       props: {
+         artists: artists.docs.map((a) => {
+           return { ...a.data(), key: a.id }
+         }),
+       }
+     }
+}
+
+export default withAuthUser({
+     whenUnauthedAfterInit: AuthAction.REDIRECT_TO_LOGIN,
+})(Artist)
+````
 
 ## Config
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,6 +8,8 @@ import type {
 } from 'next'
 import type { ComponentType } from 'react'
 import type { ParsedUrlQuery } from 'querystring'
+import firebase from "firebase";
+import app = firebase.app;
 
 export type SSRPropsContext<Q extends ParsedUrlQuery = ParsedUrlQuery> =
   GetServerSidePropsContext<Q>
@@ -72,6 +74,8 @@ interface InitConfig {
 }
 
 export const init: (config: InitConfig) => void
+
+export const getFirebaseAdmin: () => app.App
 
 export const setAuthCookies: (req: NextApiRequest, res: NextApiResponse) => Promise<{
   idToken: string;

--- a/src/__tests__/index.getFirebaseAdmin.server.test.js
+++ b/src/__tests__/index.getFirebaseAdmin.server.test.js
@@ -1,0 +1,41 @@
+/**
+ * @jest-environment node
+ */
+
+import * as admin from 'firebase-admin'
+import createMockConfig from '../testHelpers/createMockConfig'
+import { setConfig } from '../config'
+
+jest.mock('firebase-admin')
+jest.mock('src/config')
+
+beforeEach(() => {
+  const mockConfig = createMockConfig({ clientSide: false })
+  setConfig(mockConfig)
+
+  admin.credential.cert.mockImplementation((obj) => ({
+    ...obj,
+    _mockFirebaseCert: true,
+  }))
+  admin.apps = []
+})
+
+afterEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('index.server.js: getFirebaseAdmin', () => {
+  it('exports getFirebaseAdmin', () => {
+    expect.assertions(2)
+    const indexServer = require('src/index.server').default
+    expect(indexServer.getFirebaseAdmin).toBeDefined()
+    expect(indexServer.init).toEqual(expect.any(Function))
+  })
+
+  it('getFirebaseAdmin returns admin', () => {
+    expect.assertions(1)
+    const indexServer = require('src/index.server').default
+    const response = indexServer.getFirebaseAdmin()
+    expect(response).toEqual(admin)
+  })
+})

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -177,6 +177,24 @@ describe('index.js: verifyIdToken', () => {
   })
 })
 
+describe('index.js: getFirebaseAdmin', () => {
+  it('exports getFirebaseAdmin', () => {
+    expect.assertions(2)
+    const index = require('src/index').default
+    expect(index.getFirebaseAdmin).toBeDefined()
+    expect(index.getFirebaseAdmin).toEqual(expect.any(Function))
+  })
+
+  it('throws if called on the client side', () => {
+    expect.assertions(1)
+    isClientSide.mockReturnValue(true)
+    const index = require('src/index').default
+    expect(() => {
+      index.getFirebaseAdmin()
+    }).toThrow('"getFirebaseAdmin" can only be called server-side.')
+  })
+})
+
 describe('index.js: AuthAction', () => {
   it('defines the expected constants', () => {
     expect.assertions(1)

--- a/src/index.js
+++ b/src/index.js
@@ -42,6 +42,10 @@ const verifyIdToken = () => {
   throw new Error('"verifyIdToken" can only be called server-side.')
 }
 
+const getFirebaseAdmin = () => {
+  throw new Error('"getFirebaseAdmin" can only be called server-side.')
+}
+
 export default {
   init,
   withAuthUser,
@@ -52,4 +56,5 @@ export default {
   unsetAuthCookies,
   verifyIdToken,
   AuthAction,
+  getFirebaseAdmin,
 }

--- a/src/index.server.js
+++ b/src/index.server.js
@@ -7,6 +7,8 @@ import unsetAuthCookies from 'src/unsetAuthCookies'
 import withAuthUserTokenSSRModule from 'src/withAuthUserTokenSSR'
 import { verifyIdToken } from 'src/firebaseAdmin'
 
+import initFirebaseAdminSDK from 'src/initFirebaseAdminSDK'
+
 const initServer = (config) => {
   const clientInit = index.init(config)
   // We only initialize the Firebase admin SDK as it's needed. See:
@@ -20,6 +22,8 @@ const withAuthUserTokenSSR = (options) =>
 const withAuthUserSSR = (options) =>
   withAuthUserTokenSSRModule(options, { useToken: false })
 
+const getFirebaseAdmin = () => initFirebaseAdminSDK()
+
 export default {
   ...index,
   init: initServer,
@@ -28,4 +32,5 @@ export default {
   setAuthCookies,
   unsetAuthCookies,
   verifyIdToken,
+  getFirebaseAdmin,
 }


### PR DESCRIPTION
Allow the Firebase Admin application to be retrieved while running on server.

When I try and initialize the Firebase Admin app (following https://github.com/gladly-team/next-firebase-auth/discussions/61#discussioncomment-323977) I always seem to get (on initial render) an error where `admin` is undefined.

This PR will make the internally configured Firebase Admin application available to developers while working on server side.