### PR TITLE
Get Firebase Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,7 +386,7 @@ const Artists = ({ artists: ssrArtists }) => {
 }
 
 export async function getServerSideProps() {
-  // Do Server Side Wrok to get `artists` collection
+  // Do server-side work to get `artists` collection
 }
 ````
 

--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ export default withAuthUser()(Demo)
 * [unsetAuthCookies](#unsetauthcookiesreq-res)
 * [verifyIdToken](#verifyidtokentoken--promiseauthuser)
 * [AuthAction](#authaction)
+* [getFirebaseClient](#getfirebaseclient--appapp)
 * [getFirebaseAdmin](#getfirebaseadmin--appapp)
 
 -----

--- a/README.md
+++ b/README.md
@@ -345,6 +345,50 @@ Verifies a Firebase ID token and resolves to an [`AuthUser`](#authuser) instance
 
 An object that defines rendering/redirecting options for `withAuthUser` and `withAuthUserTokenSSR`. See [AuthAction](#authaction-1).
 
+#### `getFirebaseClient() => app.App`
+
+A convenience function that returns the configured Firebase Client application.
+
+This can only be called from the client side.
+
+>**Note**: It is important that the developer import each Firebase Modules that they require to use. For instance if a developer
+needs to use the Firebase Storage module then they are required to `import "firebase/storage"` to their project.
+> See [https://firebase.google.com/docs/web/setup#expandable-9](https://firebase.google.com/docs/web/setup#expandable-9) here for details.
+
+For example:
+````jsx
+import { getFirebaseClient } from 'next-firebase-auth'
+import 'firebase/firestore';  // This is very important
+import { useEffect } from "react";
+
+const Artists = ({ artists: ssrArtists }) => {
+  const [artists, setArtists] = useState(artists);
+  
+  useEffect(() => {
+    return getFirebaseClient().firestore()
+      .collection('artists')
+      .onSnapshot( (snap) => {
+        if (!snap) {
+          return
+        }
+        setArtists(snap.docs.map(doc => ({...doc.data(), key: doc.id})))
+        
+      })
+  }, []);
+  
+  return (
+    <div>
+      {artists.map((artist) => <div>{artist.name}</div>)}
+    </div>
+  )
+  
+}
+
+export async function getServerSideProps() {
+  // Do Server Side Wrok to get `artists` collection
+}
+````
+
 #### `getFirebaseAdmin() => app.App`
 
 _Added in v0.13.1-alpha.0_

--- a/index.d.ts
+++ b/index.d.ts
@@ -9,7 +9,9 @@ import type {
 import type { ComponentType } from 'react'
 import type { ParsedUrlQuery } from 'querystring'
 import firebase from "firebase";
-import app = firebase.app;
+import firebaseClientApp = firebase.app;
+
+import {app as firebaseAdminApp} from "firebase-admin";
 
 export type SSRPropsContext<Q extends ParsedUrlQuery = ParsedUrlQuery> =
   GetServerSidePropsContext<Q>
@@ -84,7 +86,7 @@ interface InitConfig {
 
 export const init: (config: InitConfig) => void
 
-export const getFirebaseAdmin: () => app.App
+export const getFirebaseAdmin: () => firebaseAdminApp.App
 
 /**
  * Get the Firebase Client API. Use this when developing on the Client (Browser).
@@ -103,7 +105,7 @@ export const getFirebaseAdmin: () => app.App
  * ```
  *
  */
-export const getFirebaseClient: () => app.App
+export const getFirebaseClient: () => firebaseClientApp.App
 
 export const setAuthCookies: (req: NextApiRequest, res: NextApiResponse) => Promise<{
   idToken: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -63,10 +63,20 @@ interface InitConfig {
   };
   firebaseAuthEmulatorHost?: string;
   firebaseClientInitConfig: {
-    apiKey: string;
-    authDomain?: string;
-    databaseURL?: string;
-    projectId?: string;
+    apiKey: string,
+    projectId: string,
+    appId: string,
+    // "PROJECT_ID.firebaseapp.com"
+    authDomain: string,
+    // "https://PROJECT_ID.firebaseio.com"
+    databaseURL: string,
+    // "PROJECT_ID.appspot.com"
+    storageBucket: string,
+    // "SENDER_ID"
+    messagingSenderId: string,
+    // "G-MEASUREMENT_ID"
+    measurementId: string,
+
   };
   cookies: Cookies.Option & Cookies.SetOption & {
     name: string;
@@ -76,6 +86,25 @@ interface InitConfig {
 export const init: (config: InitConfig) => void
 
 export const getFirebaseAdmin: () => app.App
+
+/**
+ * Get the Firebase Client API. Use this when developing on the Client (Browser).
+ * Before usage ensure that each of the Firebase Modules required are imported into
+ * the project (See https://firebase.google.com/docs/web/setup#available-libraries); for example add:
+ *
+ * @example
+ * ```
+ * // Add the Firebase products that you want to use (note that this module imports `firebase/auth` already.
+ * import "firebase/firestore";
+ * import "firebase/functions";
+ * import "firebase/messaging";
+ * import "firebase/analytics";
+ * import "firebase/storage";
+ * import "firebase/database";
+ * ```
+ *
+ */
+export const getFirebaseClient: () => app.App
 
 export const setAuthCookies: (req: NextApiRequest, res: NextApiResponse) => Promise<{
   idToken: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -64,19 +64,18 @@ interface InitConfig {
   firebaseAuthEmulatorHost?: string;
   firebaseClientInitConfig: {
     apiKey: string,
-    projectId: string,
-    appId: string,
+    projectId?: string,
+    appId?: string,
     // "PROJECT_ID.firebaseapp.com"
     authDomain: string,
     // "https://PROJECT_ID.firebaseio.com"
-    databaseURL: string,
+    databaseURL?: string,
     // "PROJECT_ID.appspot.com"
-    storageBucket: string,
+    storageBucket?: string,
     // "SENDER_ID"
-    messagingSenderId: string,
+    messagingSenderId?: string,
     // "G-MEASUREMENT_ID"
-    measurementId: string,
-
+    measurementId?: string,
   };
   cookies: Cookies.Option & Cookies.SetOption & {
     name: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -67,7 +67,7 @@ interface InitConfig {
     projectId?: string,
     appId?: string,
     // "PROJECT_ID.firebaseapp.com"
-    authDomain: string,
+    authDomain?: string,
     // "https://PROJECT_ID.firebaseio.com"
     databaseURL?: string,
     // "PROJECT_ID.appspot.com"

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -2,6 +2,7 @@ import { setConfig } from 'src/config'
 import { setDebugEnabled } from 'src/logDebug'
 import initFirebaseClientSDK from 'src/initFirebaseClientSDK'
 import isClientSide from 'src/isClientSide'
+import firebase from 'firebase/app'
 
 jest.mock('src/config')
 jest.mock('src/logDebug')
@@ -66,6 +67,39 @@ describe('index.js: init', () => {
     const index = require('src/index').default
     index.init()
     expect(initFirebaseClientSDK).not.toHaveBeenCalled()
+  })
+})
+
+describe('index.js: getFirebaseClient', () => {
+  it('exports getFirebaseClient', () => {
+    expect.assertions(2)
+    isClientSide.mockReturnValue(true)
+    const index = require('src/index').default
+    expect(index.getFirebaseClient).toBeDefined()
+    expect(index.getFirebaseClient).toEqual(expect.any(Function))
+  })
+
+  it('throws if init has not been called', () => {
+    expect.assertions(1)
+    isClientSide.mockReturnValue(true)
+    const index = require('src/index').default
+
+    expect(() => index.getFirebaseClient()).toThrow(
+      '"getFirebaseClient": Please initialise before calling'
+    )
+  })
+
+  it('Provides a Firebase Client App', () => {
+    expect.assertions(3)
+    firebase.apps = [{ name: 'app' }]
+    const index = require('src/index').default
+    expect(() => index.getFirebaseClient()).not.toThrow()
+    expect(index.getFirebaseClient()).toHaveProperty('firestore')
+    expect(index.getFirebaseClient()).toHaveProperty('functions')
+  })
+
+  afterAll(() => {
+    firebase.apps = []
   })
 })
 

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ import initFirebaseClientSDK from 'src/initFirebaseClientSDK'
 import { setDebugEnabled } from 'src/logDebug'
 import isClientSide from 'src/isClientSide'
 import AuthAction from 'src/AuthAction'
+import firebase from 'firebase/app'
 
 const init = (config = {}) => {
   setDebugEnabled(config.debug === true)
@@ -46,6 +47,14 @@ const getFirebaseAdmin = () => {
   throw new Error('"getFirebaseAdmin" can only be called server-side.')
 }
 
+const getFirebaseClient = () => {
+  if (firebase.apps.length === 0) {
+    throw new Error('"getFirebaseClient": Please initialise before calling')
+  }
+
+  return firebase
+}
+
 export default {
   init,
   withAuthUser,
@@ -57,4 +66,5 @@ export default {
   verifyIdToken,
   AuthAction,
   getFirebaseAdmin,
+  getFirebaseClient,
 }


### PR DESCRIPTION
Allow the Firebase Client application to be retrieved while running on a browser.

A small extension to the PR #144 that will allow a Developer to use the Firebase Client application. I have extended the `firebaseClientInitConfig` (TypeScript only) to accept the configuration variables defined https://firebase.google.com/docs/web/setup#add-sdks-initialize.

