### PR TITLE
Add `debug: boolean` to InitConfig type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -84,6 +84,7 @@ interface InitConfig {
     Cookies.SetOption & {
       name: string
     }
+  debug: boolean
 }
 
 export const init: (config: InitConfig) => void

--- a/index.d.ts
+++ b/index.d.ts
@@ -84,7 +84,7 @@ interface InitConfig {
     Cookies.SetOption & {
       name: string
     }
-  debug: boolean
+  debug?: boolean
 }
 
 export const init: (config: InitConfig) => void


### PR DESCRIPTION
This allows you to pass a config object with the `debug` property set, when using next-firebase-auth in a TypeScript project (without having to declare the config object as having type `any`).

Addresses #157