### PR TITLE
Remove getFirebaseClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -501,14 +501,42 @@ A method that calls Firebase's [`signOut`](https://firebase.google.com/docs/refe
 
 ## Examples
 
-### Using the Firebase App
+### Using the Firebase admin or JS App
 
 You may want to access the Firebase admin module or Firebase JS SDK.
 
-To use the Firebase admin module, you can use [`getFirebaseAdmin`](#getfirebaseadmin--appapp). If you prefer, you can instead choose to initialize Firebase yourself _prior_ to initializing `next-firebase-auth`. [Here's some example code](https://github.com/gladly-team/next-firebase-auth/discussions/61#discussioncomment-323977) with this pattern.
+To use the Firebase admin module, you can use [`getFirebaseAdmin`](#getfirebaseadmin--appapp). (If you prefer, you can instead choose to initialize Firebase yourself _prior_ to initializing `next-firebase-auth`. [Here's some example code](https://github.com/gladly-team/next-firebase-auth/discussions/61#discussioncomment-323977) with this pattern.)
 
-To use the Firebase JS SDK, simply import Firebasse as you normally would to use in your page or component.
+To use the Firebase JS SDK, simply import Firebase as you normally would. For example:
 
+```jsx
+import firebase from 'firebase/app'
+import 'firebase/firestore'
+import { useEffect } from "react"
+
+const Artists = ({ artists: ssrArtists }) => {
+  const [artists, setArtists] = useState(artists);
+  
+  useEffect(() => {
+    return firebase.firestore()
+      .collection('artists')
+      .onSnapshot( (snap) => {
+        if (!snap) {
+          return
+        }
+        setArtists(snap.docs.map(doc => ({...doc.data(), key: doc.id})))
+        
+      })
+  }, []);
+  
+  return (
+    <div>
+      {artists.map((artist) => <div>{artist.name}</div>)}
+    </div>
+  )
+  
+}
+```
 
 ### Testing and Mocking with Jest
 

--- a/README.md
+++ b/README.md
@@ -196,7 +196,6 @@ export default withAuthUser()(Demo)
 * [unsetAuthCookies](#unsetauthcookiesreq-res)
 * [verifyIdToken](#verifyidtokentoken--promiseauthuser)
 * [AuthAction](#authaction)
-* [getFirebaseClient](#getfirebaseclient--firebaseapp)
 * [getFirebaseAdmin](#getfirebaseadmin--firebaseadmin)
 
 -----
@@ -345,51 +344,6 @@ Verifies a Firebase ID token and resolves to an [`AuthUser`](#authuser) instance
 #### `AuthAction`
 
 An object that defines rendering/redirecting options for `withAuthUser` and `withAuthUserTokenSSR`. See [AuthAction](#authaction-1).
-
-#### `getFirebaseClient() => Firebase.App`
-
-_Added in v0.13.1-alpha.1_
-
-A convenience function that returns the configured Firebase Client application.
-
-This can only be called from the client side.
-
->**Note**: It is important that to import the Firebase modules that you'll use. For instance, if using Firebase storage, add `import "firebase/storage"` to their project.
-> See [Firebase setup docs](https://firebase.google.com/docs/web/setup#expandable-9) for details.
-
-For example:
-````jsx
-import { getFirebaseClient } from 'next-firebase-auth'
-import 'firebase/firestore';  // This is very important
-import { useEffect } from "react";
-
-const Artists = ({ artists: ssrArtists }) => {
-  const [artists, setArtists] = useState(artists);
-  
-  useEffect(() => {
-    return getFirebaseClient().firestore()
-      .collection('artists')
-      .onSnapshot( (snap) => {
-        if (!snap) {
-          return
-        }
-        setArtists(snap.docs.map(doc => ({...doc.data(), key: doc.id})))
-        
-      })
-  }, []);
-  
-  return (
-    <div>
-      {artists.map((artist) => <div>{artist.name}</div>)}
-    </div>
-  )
-  
-}
-
-export async function getServerSideProps() {
-  // Do server-side work to get `artists` collection
-}
-````
 
 #### `getFirebaseAdmin() => FirebaseAdmin`
 
@@ -549,9 +503,12 @@ A method that calls Firebase's [`signOut`](https://firebase.google.com/docs/refe
 
 ### Using the Firebase App
 
-You may want to access the Firebase JS SDK or admin apps. To do so, you can use [`getFirebaseClient`](#getfirebaseclient--appapp) and [`getFirebaseAdmin`](#getfirebaseadmin--appapp).
+You may want to access the Firebase admin module or Firebase JS SDK.
 
-If you prefer, you can instead choose to initialize Firebase yourself _prior_ to initializing `next-firebase-auth`. [Here's some example code](https://github.com/gladly-team/next-firebase-auth/discussions/61#discussioncomment-323977) with this pattern.
+To use the Firebase admin module, you can use [`getFirebaseAdmin`](#getfirebaseadmin--appapp). If you prefer, you can instead choose to initialize Firebase yourself _prior_ to initializing `next-firebase-auth`. [Here's some example code](https://github.com/gladly-team/next-firebase-auth/discussions/61#discussioncomment-323977) with this pattern.
+
+To use the Firebase JS SDK, simply import Firebasse as you normally would to use in your page or component.
+
 
 ### Testing and Mocking with Jest
 

--- a/README.md
+++ b/README.md
@@ -501,11 +501,11 @@ A method that calls Firebase's [`signOut`](https://firebase.google.com/docs/refe
 
 ## Examples
 
-### Using the Firebase admin or JS App
+### Using the Firebase Apps
 
 You may want to access the Firebase admin module or Firebase JS SDK.
 
-To use the Firebase admin module, you can use [`getFirebaseAdmin`](#getfirebaseadmin--appapp). (If you prefer, you can instead choose to initialize Firebase yourself _prior_ to initializing `next-firebase-auth`. [Here's some example code](https://github.com/gladly-team/next-firebase-auth/discussions/61#discussioncomment-323977) with this pattern.)
+To use the Firebase admin module, you can use [`getFirebaseAdmin`](#getfirebaseadmin--firebaseadmin). (If you prefer, you can instead choose to initialize Firebase yourself _prior_ to initializing `next-firebase-auth`. [Here's some example code](https://github.com/gladly-team/next-firebase-auth/discussions/61#discussioncomment-323977) with this pattern.)
 
 To use the Firebase JS SDK, simply import Firebase as you normally would. For example:
 
@@ -514,8 +514,8 @@ import firebase from 'firebase/app'
 import 'firebase/firestore'
 import { useEffect } from "react"
 
-const Artists = ({ artists: ssrArtists }) => {
-  const [artists, setArtists] = useState(artists);
+const Artists = () => {
+  const [artists, setArtists] = useState(artists)
   
   useEffect(() => {
     return firebase.firestore()
@@ -524,7 +524,7 @@ const Artists = ({ artists: ssrArtists }) => {
         if (!snap) {
           return
         }
-        setArtists(snap.docs.map(doc => ({...doc.data(), key: doc.id})))
+        setArtists(snap.docs.map(doc => ({ ...doc.data(), key: doc.id })))
         
       })
   }, []);

--- a/README.md
+++ b/README.md
@@ -349,7 +349,7 @@ An object that defines rendering/redirecting options for `withAuthUser` and `wit
 
 _Added in v0.13.1-alpha.0_
 
-A convenience function that returns the configured Firebase Admin application.
+A convenience function that returns the configured Firebase admin module.
 
 This can only be called from the server side. It will throw an error if called from the client side.
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -99,7 +99,7 @@ export const init: (config: InitConfig) => void
 interface FirebaseAdminType extends firebaseAdmin.app.App {
   app: firebaseAdmin.app.App
   delete: undefined
-  credential: Firebase.credential.Credential
+  credential: firebaseAdmin.credential.Credential
 }
 
 export const getFirebaseAdmin: () => FirebaseAdminType

--- a/index.d.ts
+++ b/index.d.ts
@@ -104,25 +104,6 @@ interface FirebaseAdminType extends firebaseAdmin.app.App {
 
 export const getFirebaseAdmin: () => FirebaseAdminType
 
-/**
- * Get the Firebase Client API. Use this when developing on the Client (Browser).
- * Before usage ensure that each of the Firebase Modules required are imported into
- * the project (See https://firebase.google.com/docs/web/setup#available-libraries); for example add:
- *
- * @example
- * ```
- * // Add the Firebase products that you want to use (note that this module imports `firebase/auth` already.
- * import "firebase/firestore";
- * import "firebase/functions";
- * import "firebase/messaging";
- * import "firebase/analytics";
- * import "firebase/storage";
- * import "firebase/database";
- * ```
- *
- */
-export const getFirebaseClient: () => Firebase.App
-
 export const setAuthCookies: (
   req: NextApiRequest,
   res: NextApiResponse

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -70,39 +70,6 @@ describe('index.js: init', () => {
   })
 })
 
-describe('index.js: getFirebaseClient', () => {
-  it('exports getFirebaseClient', () => {
-    expect.assertions(2)
-    isClientSide.mockReturnValue(true)
-    const index = require('src/index').default
-    expect(index.getFirebaseClient).toBeDefined()
-    expect(index.getFirebaseClient).toEqual(expect.any(Function))
-  })
-
-  it('throws if init has not been called', () => {
-    expect.assertions(1)
-    isClientSide.mockReturnValue(true)
-    const index = require('src/index').default
-
-    expect(() => index.getFirebaseClient()).toThrow(
-      '"getFirebaseClient": Please initialise before calling'
-    )
-  })
-
-  it('Provides a Firebase Client App', () => {
-    expect.assertions(3)
-    firebase.apps = [{ name: 'app' }]
-    const index = require('src/index').default
-    expect(() => index.getFirebaseClient()).not.toThrow()
-    expect(index.getFirebaseClient()).toHaveProperty('firestore')
-    expect(index.getFirebaseClient()).toHaveProperty('functions')
-  })
-
-  afterAll(() => {
-    firebase.apps = []
-  })
-})
-
 describe('index.js: withAuthUser', () => {
   it('exports withAuthUser', () => {
     expect.assertions(2)

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -2,7 +2,6 @@ import { setConfig } from 'src/config'
 import { setDebugEnabled } from 'src/logDebug'
 import initFirebaseClientSDK from 'src/initFirebaseClientSDK'
 import isClientSide from 'src/isClientSide'
-import firebase from 'firebase/app'
 
 jest.mock('src/config')
 jest.mock('src/logDebug')

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,6 @@ import initFirebaseClientSDK from 'src/initFirebaseClientSDK'
 import { setDebugEnabled } from 'src/logDebug'
 import isClientSide from 'src/isClientSide'
 import AuthAction from 'src/AuthAction'
-import firebase from 'firebase/app'
 
 const init = (config = {}) => {
   setDebugEnabled(config.debug === true)
@@ -46,15 +45,6 @@ const verifyIdToken = () => {
 const getFirebaseAdmin = () => {
   throw new Error('"getFirebaseAdmin" can only be called server-side.')
 }
-
-const getFirebaseClient = () => {
-  if (firebase.apps.length === 0) {
-    throw new Error('"getFirebaseClient": Please initialise before calling')
-  }
-
-  return firebase
-}
-
 export default {
   init,
   withAuthUser,
@@ -66,5 +56,4 @@ export default {
   verifyIdToken,
   AuthAction,
   getFirebaseAdmin,
-  getFirebaseClient,
 }


### PR DESCRIPTION
Removes an unnecessary and potentially confusing method. See #135 for discussion.