### PR TITLE
implement cookies.unified option to use unified cookie

### DIFF
--- a/src/authCookies.js
+++ b/src/authCookies.js
@@ -1,13 +1,16 @@
 import { getConfig } from 'src/config'
 
 const getBaseCookieName = () => getConfig().cookies.name
+const isCookieUnified = () => getConfig().cookies.unified
 
 export const getAuthUserCookieName = () => {
   const baseAuthCookieName = getBaseCookieName()
+  if (isCookieUnified()) return baseAuthCookieName
   return `${baseAuthCookieName}.AuthUser`
 }
 
 export const getAuthUserTokensCookieName = () => {
   const baseAuthCookieName = getBaseCookieName()
+  if (isCookieUnified()) return baseAuthCookieName
   return `${baseAuthCookieName}.AuthUserTokens`
 }

--- a/src/config.js
+++ b/src/config.js
@@ -55,6 +55,7 @@ const defaultConfig = {
     sameSite: 'strict',
     secure: true,
     signed: true,
+    unified: false,
   },
 }
 
@@ -185,6 +186,7 @@ export const setConfig = (userConfig = {}) => {
     cookies: {
       ...defaultConfig.cookies,
       ...cookieOptions,
+      signed: cookieOptions.unified ? false : cookieOptions.signed
     },
   }
   const { isValid, errors } = validateConfig(mergedConfig)

--- a/src/setAuthCookies.js
+++ b/src/setAuthCookies.js
@@ -47,15 +47,7 @@ const setAuthCookies = async (req, res) => {
     signed,
   }))(getConfig().cookies)
 
-  if(unified) {
-    setCookie(
-      name,
-      `${JSON.stringify({idToken, refreshToken})}|-|${AuthUser.serialize({ includeToken: false })}`,
-      {req, res},
-      cookieOptions
-    )
-  } else {
-
+  if(!unified) {
     // Store the ID and refresh tokens in a cookie. This
     // cookie will be available to future requests to pages,
     // providing a valid Firebase ID token (refreshed as needed)
@@ -90,6 +82,13 @@ const setAuthCookies = async (req, res) => {
         req,
         res,
       },
+      cookieOptions
+    )
+  } else {
+    setCookie(
+      name,
+      `${JSON.stringify({idToken, refreshToken})}|-|${AuthUser.serialize({ includeToken: false })}`,
+      {req, res},
       cookieOptions
     )
   }

--- a/src/setAuthCookies.js
+++ b/src/setAuthCookies.js
@@ -21,6 +21,8 @@ const setAuthCookies = async (req, res) => {
     token
   )
 
+  const { unified, name } = getConfig().cookies;
+
   // Pick a subset of the config.cookies options to
   // pass to setCookie.
   const cookieOptions = (({
@@ -45,43 +47,52 @@ const setAuthCookies = async (req, res) => {
     signed,
   }))(getConfig().cookies)
 
-  // Store the ID and refresh tokens in a cookie. This
-  // cookie will be available to future requests to pages,
-  // providing a valid Firebase ID token (refreshed as needed)
-  // for server-side rendering.
-  setCookie(
-    getAuthUserTokensCookieName(),
-    // Note: any change to cookie data structure needs to be
-    // backwards-compatible.
-    JSON.stringify({
-      idToken,
-      refreshToken,
-    }),
-    { req, res },
-    cookieOptions
-  )
+  if(unified) {
+    setCookie(
+      name,
+      `${JSON.stringify({idToken, refreshToken})}|-|${AuthUser.serialize({ includeToken: false })}`,
+      {req, res},
+      cookieOptions
+    )
+  } else {
 
-  // Store the AuthUser data. This cookie will be available
-  // to future requests to pages, providing the user data. It
-  // will *not* include a Firebase ID token, because it may have
-  // expired, but provides the AuthUser data without any
-  // additional server-side requests.
-  setCookie(
-    getAuthUserCookieName(),
-    // Note: any change to cookie data structure needs to be
-    // backwards-compatible.
-    // Don't include the token in the "AuthUser" cookie, because
-    // the token should only be used from the "AuthUserTokens"
-    // cookie. Here, it is redundant information, and we don't
-    // want the token to be used if it's expired.
-    AuthUser.serialize({ includeToken: false }),
-    {
-      req,
-      res,
-    },
-    cookieOptions
-  )
+    // Store the ID and refresh tokens in a cookie. This
+    // cookie will be available to future requests to pages,
+    // providing a valid Firebase ID token (refreshed as needed)
+    // for server-side rendering.
+    setCookie(
+      getAuthUserTokensCookieName(),
+      // Note: any change to cookie data structure needs to be
+      // backwards-compatible.
+      JSON.stringify({
+        idToken,
+        refreshToken,
+      }),
+      { req, res },
+      cookieOptions
+    )
 
+    // Store the AuthUser data. This cookie will be available
+    // to future requests to pages, providing the user data. It
+    // will *not* include a Firebase ID token, because it may have
+    // expired, but provides the AuthUser data without any
+    // additional server-side requests.
+    setCookie(
+      getAuthUserCookieName(),
+      // Note: any change to cookie data structure needs to be
+      // backwards-compatible.
+      // Don't include the token in the "AuthUser" cookie, because
+      // the token should only be used from the "AuthUserTokens"
+      // cookie. Here, it is redundant information, and we don't
+      // want the token to be used if it's expired.
+      AuthUser.serialize({ includeToken: false }),
+      {
+        req,
+        res,
+      },
+      cookieOptions
+    )
+  }
   return {
     idToken,
     refreshToken,

--- a/src/withAuthUserTokenSSR.js
+++ b/src/withAuthUserTokenSSR.js
@@ -42,7 +42,7 @@ const withAuthUserTokenSSR = (
 ) => (getServerSidePropsFunc) => async (ctx) => {
   const { req, res } = ctx
 
-  const { keys, secure, signed } = getConfig().cookies
+  const { keys, secure, signed, unified } = getConfig().cookies
 
   let AuthUser
 
@@ -55,7 +55,7 @@ const withAuthUserTokenSSR = (
   if (useToken) {
     // Get the user's ID token from a cookie, verify it (refreshing
     // as needed), and return the serialized AuthUser in props.
-    const cookieValStr = getCookie(
+    let cookieValStr = getCookie(
       getAuthUserTokensCookieName(),
       {
         req,
@@ -63,6 +63,7 @@ const withAuthUserTokenSSR = (
       },
       { keys, secure, signed }
     )
+    if (unified && cookieValStr) cookieValStr = cookieValStr.split('|-|')[0];
     const { idToken, refreshToken } = cookieValStr
       ? JSON.parse(cookieValStr)
       : {}
@@ -74,7 +75,7 @@ const withAuthUserTokenSSR = (
   } else {
     // Get the user's info from a cookie, verify it (refreshing
     // as needed), and return the serialized AuthUser in props.
-    const cookieValStr = getCookie(
+    let cookieValStr = getCookie(
       getAuthUserCookieName(),
       {
         req,
@@ -82,6 +83,7 @@ const withAuthUserTokenSSR = (
       },
       { keys, secure, signed }
     )
+    if (unified && cookieValStr) cookieValStr = cookieValStr.split('|-|')[1];
     AuthUser = createAuthUser({
       serializedAuthUser: cookieValStr,
     })


### PR DESCRIPTION
This PR implements a very basic solution to save authentication cookies in one single `unified` cookie. This can be used in scenarios where only a single cookie is allowed, e.g. firebase hosting (see #190). 

I already tested this version on a deployment with cloud.run + firebase hosting and it works when the cookie is name `__session`. (as mentioned in their documentation)

I consider this solution the most straightforward approach I could offer—but please point me in the right directions to get his feature merged!

- related to #190 