### PR TITLE
Fix race condition described in issue #189

### DIFF
--- a/src/useFirebaseUser.js
+++ b/src/useFirebaseUser.js
@@ -72,9 +72,9 @@ const useFirebaseUser = () => {
       const claims = filterStandardClaims(idTokenResult.claims)
       setCustomClaims(claims)
     }
+    await setAuthCookie(firebaseUser)
     setUser(firebaseUser)
     setInitialized(true)
-    await setAuthCookie(firebaseUser)
   }
 
   useEffect(() => {

--- a/src/useFirebaseUser.js
+++ b/src/useFirebaseUser.js
@@ -63,6 +63,7 @@ const useFirebaseUser = () => {
   const [user, setUser] = useState()
   const [customClaims, setCustomClaims] = useState({})
   const [initialized, setInitialized] = useState(false)
+  const [authCookieComplete, setAuthCookieComplete] = useState(false)
 
   async function onIdTokenChange(firebaseUser) {
     if (firebaseUser) {
@@ -72,9 +73,9 @@ const useFirebaseUser = () => {
       const claims = filterStandardClaims(idTokenResult.claims)
       setCustomClaims(claims)
     }
-    await setAuthCookie(firebaseUser)
     setUser(firebaseUser)
     setInitialized(true)
+    await setAuthCookie(firebaseUser).then(() => setAuthCookieComplete(true))
   }
 
   useEffect(() => {
@@ -87,6 +88,7 @@ const useFirebaseUser = () => {
     user, // unmodified Firebase user, undefined if not authed
     claims: customClaims,
     initialized,
+    authCookieComplete,
   }
 }
 


### PR DESCRIPTION
Simple fix proposed by Kevin to await the call to `setAuthCookie` before the redirct happens.

Closes https://github.com/gladly-team/next-firebase-auth/issues/189