### PR TITLE
Wait for login/logout requests to complete before redirecting

### DIFF
--- a/src/__tests__/useFirebaseUser.test.js
+++ b/src/__tests__/useFirebaseUser.test.js
@@ -37,7 +37,7 @@ describe('useFirebaseUser', () => {
       user: undefined,
       claims: {},
       initialized: false,
-      loginRequestCompleted: false,
+      authRequestCompleted: false,
     })
   })
 
@@ -73,7 +73,7 @@ describe('useFirebaseUser', () => {
       user: mockFirebaseUser,
       claims: {},
       initialized: true,
-      loginRequestCompleted: true,
+      authRequestCompleted: true,
     })
   })
 
@@ -108,7 +108,7 @@ describe('useFirebaseUser', () => {
       user: undefined,
       claims: {},
       initialized: true,
-      loginRequestCompleted: true,
+      authRequestCompleted: true,
     })
   })
 
@@ -155,7 +155,7 @@ describe('useFirebaseUser', () => {
         subscription: true,
       },
       initialized: true,
-      loginRequestCompleted: true,
+      authRequestCompleted: true,
     })
   })
 
@@ -433,7 +433,7 @@ describe('useFirebaseUser', () => {
       user: mockFirebaseUser,
       claims: {},
       initialized: true,
-      loginRequestCompleted: false,
+      authRequestCompleted: false,
     })
 
     await act(async () => {
@@ -445,7 +445,7 @@ describe('useFirebaseUser', () => {
       user: mockFirebaseUser,
       claims: {},
       initialized: true,
-      loginRequestCompleted: true,
+      authRequestCompleted: true,
     })
   })
 
@@ -494,7 +494,7 @@ describe('useFirebaseUser', () => {
       user: mockFirebaseUser,
       claims: {},
       initialized: true,
-      loginRequestCompleted: false,
+      authRequestCompleted: false,
     })
 
     await act(async () => {
@@ -506,7 +506,7 @@ describe('useFirebaseUser', () => {
       user: mockFirebaseUser,
       claims: {},
       initialized: true,
-      loginRequestCompleted: true,
+      authRequestCompleted: true,
     })
   })
 })

--- a/src/__tests__/useFirebaseUser.test.js
+++ b/src/__tests__/useFirebaseUser.test.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import firebase from 'firebase/app'
 import { renderHook, act } from '@testing-library/react-hooks'
 import useFirebaseUser from 'src/useFirebaseUser'

--- a/src/__tests__/useFirebaseUser.test.js
+++ b/src/__tests__/useFirebaseUser.test.js
@@ -37,7 +37,7 @@ describe('useFirebaseUser', () => {
       user: undefined,
       claims: {},
       initialized: false,
-      setAuthCookieComplete: false,
+      loginRequestCompleted: false,
     })
   })
 
@@ -73,7 +73,7 @@ describe('useFirebaseUser', () => {
       user: mockFirebaseUser,
       claims: {},
       initialized: true,
-      setAuthCookieComplete: true,
+      loginRequestCompleted: true,
     })
   })
 
@@ -108,7 +108,7 @@ describe('useFirebaseUser', () => {
       user: undefined,
       claims: {},
       initialized: true,
-      setAuthCookieComplete: true,
+      loginRequestCompleted: true,
     })
   })
 
@@ -155,7 +155,7 @@ describe('useFirebaseUser', () => {
         subscription: true,
       },
       initialized: true,
-      setAuthCookieComplete: true,
+      loginRequestCompleted: true,
     })
   })
 
@@ -433,7 +433,7 @@ describe('useFirebaseUser', () => {
       user: mockFirebaseUser,
       claims: {},
       initialized: true,
-      setAuthCookieComplete: false,
+      loginRequestCompleted: false,
     })
 
     await act(async () => {
@@ -445,7 +445,7 @@ describe('useFirebaseUser', () => {
       user: mockFirebaseUser,
       claims: {},
       initialized: true,
-      setAuthCookieComplete: true,
+      loginRequestCompleted: true,
     })
   })
 
@@ -494,7 +494,7 @@ describe('useFirebaseUser', () => {
       user: mockFirebaseUser,
       claims: {},
       initialized: true,
-      setAuthCookieComplete: false,
+      loginRequestCompleted: false,
     })
 
     await act(async () => {
@@ -506,7 +506,7 @@ describe('useFirebaseUser', () => {
       user: mockFirebaseUser,
       claims: {},
       initialized: true,
-      setAuthCookieComplete: true,
+      loginRequestCompleted: true,
     })
   })
 })

--- a/src/__tests__/withAuthUser.test.js
+++ b/src/__tests__/withAuthUser.test.js
@@ -666,7 +666,7 @@ describe('withAuthUser: rendering/redirecting', () => {
     )
   })
 
-  it('renders null when redirecting to login and whenUnauthedBeforeInit is AuthAction.RETURN_NULL', () => {
+  it('renders null when redirecting to login and whenUnauthedBeforeInit === AuthAction.RETURN_NULL', () => {
     expect.assertions(1)
     const withAuthUser = require('src/withAuthUser').default
     const MockSerializedAuthUser = undefined // no server-side user
@@ -690,7 +690,33 @@ describe('withAuthUser: rendering/redirecting', () => {
     expect(container.firstChild).toBeNull()
   })
 
-  it('renders the child component when redirecting to login and whenUnauthedBeforeInit is *not* AuthAction.RETURN_NULL', () => {
+  it('renders the loader when redirecting to login and whenUnauthedBeforeInit === AuthAction.SHOW_LOADER', () => {
+    expect.assertions(1)
+    const withAuthUser = require('src/withAuthUser').default
+    const MockSerializedAuthUser = undefined // no server-side user
+    useFirebaseUser.mockReturnValue({
+      ...getUseFirebaseUserResponse(),
+      user: undefined, // no client-side user
+      initialized: true, // already initialized
+      authRequestCompleted: true,
+    })
+    const MyLoader = () => <div>Things are loading up!</div>
+    const MockCompWithUser = withAuthUser({
+      whenUnauthedBeforeInit: AuthAction.SHOW_LOADER,
+      whenUnauthedAfterInit: AuthAction.REDIRECT_TO_LOGIN,
+      whenAuthed: AuthAction.RENDER,
+      LoaderComponent: MyLoader,
+    })(MockComponent)
+    const { queryByText } = render(
+      <MockCompWithUser
+        serializedAuthUser={MockSerializedAuthUser}
+        message="How are you?"
+      />
+    )
+    expect(queryByText('Things are loading up!')).toBeTruthy()
+  })
+
+  it('renders the child component when redirecting to login and whenUnauthedBeforeInit === AuthAction.RENDER', () => {
     expect.assertions(1)
     const withAuthUser = require('src/withAuthUser').default
     const MockSerializedAuthUser = undefined // no server-side user

--- a/src/__tests__/withAuthUser.test.js
+++ b/src/__tests__/withAuthUser.test.js
@@ -27,7 +27,7 @@ const getUseFirebaseUserResponse = () => ({
   user: undefined,
   claims: {},
   initialized: false,
-  loginRequestCompleted: false,
+  authRequestCompleted: false,
 })
 
 beforeEach(() => {
@@ -123,7 +123,7 @@ describe('withAuthUser: rendering/redirecting', () => {
       ...getUseFirebaseUserResponse(),
       user: createMockFirebaseUserClientSDK(), // client-side user exists
       initialized: true,
-      loginRequestCompleted: true,
+      authRequestCompleted: true,
     })
     const MockCompWithUser = withAuthUser({
       whenUnauthedBeforeInit: AuthAction.RENDER,
@@ -162,7 +162,7 @@ describe('withAuthUser: rendering/redirecting', () => {
       ...getUseFirebaseUserResponse(),
       user: createMockFirebaseUserClientSDK(),
       initialized: true,
-      loginRequestCompleted: true,
+      authRequestCompleted: true,
     })
     rerender(
       <MockCompWithUser
@@ -181,7 +181,7 @@ describe('withAuthUser: rendering/redirecting', () => {
       ...getUseFirebaseUserResponse(),
       user: undefined, // no client-side user
       initialized: false, // not yet initialized
-      loginRequestCompleted: false,
+      authRequestCompleted: false,
     })
     const MyLoader = () => <div>Things are loading up!</div>
     const MockCompWithUser = withAuthUser({
@@ -231,7 +231,7 @@ describe('withAuthUser: rendering/redirecting', () => {
       ...getUseFirebaseUserResponse(),
       user: undefined, // no client-side user
       initialized: false, // not yet initialized
-      loginRequestCompleted: false,
+      authRequestCompleted: false,
     })
     const mockConfig = getMockConfig()
     setConfig({
@@ -262,7 +262,7 @@ describe('withAuthUser: rendering/redirecting', () => {
       ...getUseFirebaseUserResponse(),
       user: undefined, // no client-side user
       initialized: false, // not initialized
-      loginRequestCompleted: false, // login request not completed
+      authRequestCompleted: false, // login request not completed
     })
     const mockConfig = getMockConfig()
     setConfig({
@@ -285,7 +285,7 @@ describe('withAuthUser: rendering/redirecting', () => {
       ...getUseFirebaseUserResponse(),
       user: undefined,
       initialized: true, // changed
-      loginRequestCompleted: false,
+      authRequestCompleted: false,
     })
     rerender(
       <MockCompWithUser
@@ -298,7 +298,7 @@ describe('withAuthUser: rendering/redirecting', () => {
       ...getUseFirebaseUserResponse(),
       user: undefined,
       initialized: true,
-      loginRequestCompleted: true, // changed
+      authRequestCompleted: true, // changed
     })
     rerender(
       <MockCompWithUser
@@ -319,7 +319,7 @@ describe('withAuthUser: rendering/redirecting', () => {
       ...getUseFirebaseUserResponse(),
       user: undefined, // no client-side user
       initialized: false, // not yet initialized
-      loginRequestCompleted: false,
+      authRequestCompleted: false,
     })
     const mockConfig = getMockConfig()
     setConfig({
@@ -350,7 +350,7 @@ describe('withAuthUser: rendering/redirecting', () => {
       ...getUseFirebaseUserResponse(),
       user: undefined, // no client-side user
       initialized: true, // already initialized
-      loginRequestCompleted: true,
+      authRequestCompleted: true,
     })
     const mockConfig = getMockConfig()
     setConfig({
@@ -391,7 +391,7 @@ describe('withAuthUser: rendering/redirecting', () => {
       ...getUseFirebaseUserResponse(),
       user: undefined, // no client-side user exists
       initialized: true,
-      loginRequestCompleted: true,
+      authRequestCompleted: true,
     })
     const mockConfig = getMockConfig()
     setConfig({
@@ -431,7 +431,7 @@ describe('withAuthUser: rendering/redirecting', () => {
       ...getUseFirebaseUserResponse(),
       user: undefined, // no client-side user
       initialized: true, // already initialized
-      loginRequestCompleted: true,
+      authRequestCompleted: true,
     })
     const mockConfig = getMockConfig()
     let propsSpy
@@ -467,7 +467,7 @@ describe('withAuthUser: rendering/redirecting', () => {
       user: createMockFirebaseUserClientSDK(), // client-side user exists
       claims: undefined,
       initialized: false,
-      loginRequestCompleted: false,
+      authRequestCompleted: false,
     })
     const mockConfig = getMockConfig()
     setConfig({
@@ -491,7 +491,7 @@ describe('withAuthUser: rendering/redirecting', () => {
       user: createMockFirebaseUserClientSDK(),
       claims: undefined,
       initialized: true, // changed
-      loginRequestCompleted: false,
+      authRequestCompleted: false,
     })
     rerender(
       <MockCompWithUser
@@ -505,7 +505,7 @@ describe('withAuthUser: rendering/redirecting', () => {
       user: createMockFirebaseUserClientSDK(),
       claims: undefined,
       initialized: true,
-      loginRequestCompleted: true, // changed
+      authRequestCompleted: true, // changed
     })
     rerender(
       <MockCompWithUser
@@ -527,7 +527,7 @@ describe('withAuthUser: rendering/redirecting', () => {
       user: createMockFirebaseUserClientSDK(), // client-side user exists
       claims: undefined,
       initialized: true,
-      loginRequestCompleted: true,
+      authRequestCompleted: true,
     })
     const mockConfig = getMockConfig()
     setConfig({
@@ -556,7 +556,7 @@ describe('withAuthUser: rendering/redirecting', () => {
       ...getUseFirebaseUserResponse(),
       user: createMockFirebaseUserClientSDK(), // client-side user exists
       initialized: true,
-      loginRequestCompleted: true,
+      authRequestCompleted: true,
     })
     const mockConfig = getMockConfig()
     setConfig({
@@ -597,7 +597,7 @@ describe('withAuthUser: rendering/redirecting', () => {
       ...getUseFirebaseUserResponse(),
       user: createMockFirebaseUserClientSDK(), // client-side user exists
       initialized: true,
-      loginRequestCompleted: true,
+      authRequestCompleted: true,
     })
     const mockConfig = getMockConfig()
     setConfig({
@@ -638,7 +638,7 @@ describe('withAuthUser: rendering/redirecting', () => {
       ...getUseFirebaseUserResponse(),
       user: createMockFirebaseUserClientSDK(), // client-side user exists
       initialized: true,
-      loginRequestCompleted: true,
+      authRequestCompleted: true,
     })
     const mockConfig = getMockConfig()
     let ctxSpy
@@ -674,7 +674,7 @@ describe('withAuthUser: rendering/redirecting', () => {
       ...getUseFirebaseUserResponse(),
       user: undefined, // no client-side user
       initialized: true, // already initialized
-      loginRequestCompleted: true,
+      authRequestCompleted: true,
     })
     const MockCompWithUser = withAuthUser({
       whenUnauthedBeforeInit: AuthAction.RETURN_NULL,
@@ -698,7 +698,7 @@ describe('withAuthUser: rendering/redirecting', () => {
       ...getUseFirebaseUserResponse(),
       user: undefined, // no client-side user
       initialized: true, // already initialized
-      loginRequestCompleted: true,
+      authRequestCompleted: true,
     })
     const MockCompWithUser = withAuthUser({
       whenUnauthedBeforeInit: AuthAction.RENDER,
@@ -722,7 +722,7 @@ describe('withAuthUser: rendering/redirecting', () => {
       ...getUseFirebaseUserResponse(),
       user: createMockFirebaseUserClientSDK(), // client-side user exists
       initialized: true,
-      loginRequestCompleted: true,
+      authRequestCompleted: true,
     })
     const MockCompWithUser = withAuthUser({
       whenUnauthedBeforeInit: AuthAction.RENDER,
@@ -738,7 +738,7 @@ describe('withAuthUser: rendering/redirecting', () => {
     expect(container.firstChild).toBeNull()
   })
 
-  it('renders null when redirecting to the app, even while waiting for loginRequestCompleted', () => {
+  it('renders null when redirecting to the app, even while waiting for authRequestCompleted', () => {
     expect.assertions(1)
     const withAuthUser = require('src/withAuthUser').default
     const MockSerializedAuthUser = undefined // no server-side user
@@ -746,7 +746,7 @@ describe('withAuthUser: rendering/redirecting', () => {
       ...getUseFirebaseUserResponse(),
       user: createMockFirebaseUserClientSDK(), // client-side user exists
       initialized: true,
-      loginRequestCompleted: false, // waiting
+      authRequestCompleted: false, // waiting
     })
     const MockCompWithUser = withAuthUser({
       whenUnauthedBeforeInit: AuthAction.RENDER,
@@ -840,7 +840,7 @@ describe('withAuthUser: AuthUser context', () => {
       ...getUseFirebaseUserResponse(),
       user: mockFirebaseUser, // client-side user exists
       initialized: true,
-      loginRequestCompleted: true,
+      authRequestCompleted: true,
     })
     const expectedAuthUser = {
       ...createAuthUser({
@@ -877,7 +877,7 @@ describe('withAuthUser: AuthUser context', () => {
       ...getUseFirebaseUserResponse(),
       user: mockFirebaseUser, // client-side user exists
       initialized: true,
-      loginRequestCompleted: true,
+      authRequestCompleted: true,
     })
 
     // Will use the client-side user when both exist.
@@ -952,7 +952,7 @@ describe('withAuthUser: AuthUser context', () => {
       ...getUseFirebaseUserResponse(),
       user: undefined,
       initialized: true,
-      loginRequestCompleted: true,
+      authRequestCompleted: true,
     })
 
     // Will use the (unauthenticated) user when the Firebase JS SDK
@@ -1036,7 +1036,7 @@ describe('withAuthUser: AuthUser context', () => {
         very: 'cool',
       },
       initialized: true,
-      loginRequestCompleted: true,
+      authRequestCompleted: true,
     })
     const expectedAuthUser = {
       ...createAuthUser({

--- a/src/config.js
+++ b/src/config.js
@@ -174,7 +174,9 @@ const validateConfig = (mergedConfig) => {
 }
 
 export const setConfig = (userConfig = {}) => {
+  // TODO: strip private values from log.
   logDebug('Setting config with provided value:', userConfig)
+
   const { cookies: cookieOptions = {}, ...otherUserConfig } = userConfig
 
   // Merge the user's config with the default config, validate it,

--- a/src/createAuthUser.js
+++ b/src/createAuthUser.js
@@ -48,14 +48,6 @@ const createAuthUser = ({
   token = null,
   claims,
 } = {}) => {
-  logDebug('Called createAuthUser with arguments:', {
-    firebaseUserClientSDK,
-    firebaseUserAdminSDK,
-    serializedAuthUser,
-    clientInitialized,
-    token,
-    claims,
-  })
   // Ensure only one of the user input types is defined.
   const numUserInputsDefined = [
     firebaseUserClientSDK,

--- a/src/createAuthUser.js
+++ b/src/createAuthUser.js
@@ -1,5 +1,4 @@
 /* eslint no-underscore-dangle: 0 */
-import logDebug from 'src/logDebug'
 import isClientSide from 'src/isClientSide'
 import { filterStandardClaims } from 'src/claims'
 

--- a/src/useFirebaseUser.js
+++ b/src/useFirebaseUser.js
@@ -72,8 +72,7 @@ const useFirebaseUser = () => {
   async function onIdTokenChange(firebaseUser) {
     logDebug('Firebase ID token changed. Firebase user:', firebaseUser)
 
-    // TODO: write tests and enable this:
-    // setIsAuthCookieRequestComplete(false)
+    setIsAuthCookieRequestComplete(false)
     if (firebaseUser) {
       // Get the user's claims:
       // https://firebase.google.com/docs/reference/js/firebase.auth.IDTokenResult

--- a/src/useFirebaseUser.js
+++ b/src/useFirebaseUser.js
@@ -71,6 +71,9 @@ const useFirebaseUser = () => {
 
   async function onIdTokenChange(firebaseUser) {
     logDebug('Firebase ID token changed. Firebase user:', firebaseUser)
+
+    // TODO: write tests and enable this:
+    // setIsAuthCookieRequestComplete(false)
     if (firebaseUser) {
       // Get the user's claims:
       // https://firebase.google.com/docs/reference/js/firebase.auth.IDTokenResult
@@ -79,11 +82,13 @@ const useFirebaseUser = () => {
       setCustomClaims(claims)
     }
 
+    // TODO: combine state updates
     setUser(firebaseUser)
     setInitialized(true)
 
     logDebug('Starting auth API request via tokenChangedHandler.')
 
+    // FIXME: cancel on unmount.
     await setAuthCookie(firebaseUser)
 
     setIsAuthCookieRequestComplete(true)

--- a/src/useFirebaseUser.js
+++ b/src/useFirebaseUser.js
@@ -63,6 +63,7 @@ const useFirebaseUser = () => {
   const [user, setUser] = useState()
   const [customClaims, setCustomClaims] = useState({})
   const [initialized, setInitialized] = useState(false)
+  const [isAuthCookieComplete, setAuthCookieComplete] = useState(false)
 
   async function onIdTokenChange(firebaseUser) {
     if (firebaseUser) {
@@ -75,6 +76,7 @@ const useFirebaseUser = () => {
     setUser(firebaseUser)
     setInitialized(true)
     await setAuthCookie(firebaseUser)
+    setAuthCookieComplete(true)
   }
 
   useEffect(() => {
@@ -87,6 +89,7 @@ const useFirebaseUser = () => {
     user, // unmodified Firebase user, undefined if not authed
     claims: customClaims,
     initialized,
+    setAuthCookieComplete: isAuthCookieComplete,
   }
 }
 

--- a/src/useFirebaseUser.js
+++ b/src/useFirebaseUser.js
@@ -92,7 +92,7 @@ const useFirebaseUser = () => {
     user, // unmodified Firebase user, undefined if not authed
     claims: customClaims,
     initialized,
-    loginRequestCompleted: isAuthCookieRequestComplete,
+    authRequestCompleted: isAuthCookieRequestComplete,
   }
 }
 

--- a/src/useFirebaseUser.js
+++ b/src/useFirebaseUser.js
@@ -69,35 +69,53 @@ const useFirebaseUser = () => {
     setIsAuthCookieRequestComplete,
   ] = useState(false)
 
-  async function onIdTokenChange(firebaseUser) {
-    logDebug('Firebase ID token changed. Firebase user:', firebaseUser)
+  useEffect(() => {
+    let isCancelled = false
 
-    setIsAuthCookieRequestComplete(false)
-    if (firebaseUser) {
-      // Get the user's claims:
-      // https://firebase.google.com/docs/reference/js/firebase.auth.IDTokenResult
-      const idTokenResult = await firebase.auth().currentUser.getIdTokenResult()
-      const claims = filterStandardClaims(idTokenResult.claims)
-      setCustomClaims(claims)
+    const onIdTokenChange = async (firebaseUser) => {
+      logDebug('Firebase ID token changed. Firebase user:', firebaseUser)
+
+      setIsAuthCookieRequestComplete(false)
+      if (firebaseUser) {
+        // Get the user's claims:
+        // https://firebase.google.com/docs/reference/js/firebase.auth.IDTokenResult
+        const idTokenResult = await firebase
+          .auth()
+          .currentUser.getIdTokenResult()
+        const claims = filterStandardClaims(idTokenResult.claims)
+        setCustomClaims(claims)
+      }
+
+      // TODO: combine state updates
+      setUser(firebaseUser)
+      setInitialized(true)
+
+      logDebug('Starting auth API request via tokenChangedHandler.')
+
+      await setAuthCookie(firebaseUser)
+
+      // Cancel state updates if the component has unmounted. We could abort
+      // fetches, but that would not currently support any async logic in the
+      // user-defined "tokenChangedHandler" option.
+      // https://developers.google.com/web/updates/2017/09/abortable-fetch
+      // If we were to do the above, we might optionally have
+      // "tokenChangedHandler" return an unsubscribe function.
+      if (!isCancelled) {
+        setIsAuthCookieRequestComplete(true)
+        logDebug('Completed auth API request via tokenChangedHandler.')
+      } else {
+        logDebug(
+          'Component unmounted before completing auth API request via tokenChangedHandler.'
+        )
+      }
     }
 
-    // TODO: combine state updates
-    setUser(firebaseUser)
-    setInitialized(true)
-
-    logDebug('Starting auth API request via tokenChangedHandler.')
-
-    // FIXME: cancel on unmount.
-    await setAuthCookie(firebaseUser)
-
-    setIsAuthCookieRequestComplete(true)
-    logDebug('Completed auth API request via tokenChangedHandler.')
-  }
-
-  useEffect(() => {
     // https://firebase.google.com/docs/reference/js/firebase.auth.Auth#onidtokenchanged
     const unsubscribe = firebase.auth().onIdTokenChanged(onIdTokenChange)
-    return () => unsubscribe()
+    return () => {
+      unsubscribe()
+      isCancelled = true
+    }
   }, [])
 
   return {

--- a/src/useFirebaseUser.js
+++ b/src/useFirebaseUser.js
@@ -4,6 +4,7 @@ import 'firebase/auth'
 import { getConfig } from 'src/config'
 import createAuthUser from 'src/createAuthUser'
 import { filterStandardClaims } from 'src/claims'
+import logDebug from 'src/logDebug'
 
 const defaultTokenChangedHandler = async (authUser) => {
   const { loginAPIEndpoint, logoutAPIEndpoint } = getConfig()
@@ -69,6 +70,7 @@ const useFirebaseUser = () => {
   ] = useState(false)
 
   async function onIdTokenChange(firebaseUser) {
+    logDebug('Firebase ID token changed. Firebase user:', firebaseUser)
     if (firebaseUser) {
       // Get the user's claims:
       // https://firebase.google.com/docs/reference/js/firebase.auth.IDTokenResult
@@ -76,10 +78,16 @@ const useFirebaseUser = () => {
       const claims = filterStandardClaims(idTokenResult.claims)
       setCustomClaims(claims)
     }
+
     setUser(firebaseUser)
     setInitialized(true)
+
+    logDebug('Starting auth API request via tokenChangedHandler.')
+
     await setAuthCookie(firebaseUser)
+
     setIsAuthCookieRequestComplete(true)
+    logDebug('Completed auth API request via tokenChangedHandler.')
   }
 
   useEffect(() => {

--- a/src/useFirebaseUser.js
+++ b/src/useFirebaseUser.js
@@ -63,7 +63,10 @@ const useFirebaseUser = () => {
   const [user, setUser] = useState()
   const [customClaims, setCustomClaims] = useState({})
   const [initialized, setInitialized] = useState(false)
-  const [isAuthCookieComplete, setAuthCookieComplete] = useState(false)
+  const [
+    isAuthCookieRequestComplete,
+    setIsAuthCookieRequestComplete,
+  ] = useState(false)
 
   async function onIdTokenChange(firebaseUser) {
     if (firebaseUser) {
@@ -76,7 +79,7 @@ const useFirebaseUser = () => {
     setUser(firebaseUser)
     setInitialized(true)
     await setAuthCookie(firebaseUser)
-    setAuthCookieComplete(true)
+    setIsAuthCookieRequestComplete(true)
   }
 
   useEffect(() => {
@@ -89,7 +92,7 @@ const useFirebaseUser = () => {
     user, // unmodified Firebase user, undefined if not authed
     claims: customClaims,
     initialized,
-    setAuthCookieComplete: isAuthCookieComplete,
+    loginRequestCompleted: isAuthCookieRequestComplete,
   }
 }
 

--- a/src/withAuthUser.js
+++ b/src/withAuthUser.js
@@ -6,6 +6,7 @@ import useFirebaseUser from 'src/useFirebaseUser'
 import { getConfig } from 'src/config'
 import AuthAction from 'src/AuthAction'
 import isClientSide from 'src/isClientSide'
+import logDebug from 'src/logDebug'
 
 /**
  * A higher-order component that provides pages with the
@@ -107,6 +108,7 @@ const withAuthUser = ({
 
     const router = useRouter()
     const redirectToApp = useCallback(() => {
+      logDebug('Redirecting to app.')
       const appRedirectDestination = appPageURL || getConfig().appPageURL
       if (!appRedirectDestination) {
         throw new Error(
@@ -127,6 +129,7 @@ const withAuthUser = ({
       router.replace(destination)
     }, [router, AuthUser])
     const redirectToLogin = useCallback(() => {
+      logDebug('Redirecting to login.')
       const authRedirectDestination = authPageURL || getConfig().authPageURL
       if (!authRedirectDestination) {
         throw new Error(
@@ -190,11 +193,13 @@ const withAuthUser = ({
       } else if (whenUnauthedBeforeInit === AuthAction.RETURN_NULL) {
         returnVal = null
       } else {
-        return comps
+        returnVal = comps
       }
     } else {
-      return comps
+      returnVal = comps
     }
+
+    logDebug('AuthUser set to:', AuthUser)
 
     return returnVal
   }

--- a/src/withAuthUser.js
+++ b/src/withAuthUser.js
@@ -77,6 +77,7 @@ const withAuthUser = ({
     // * the user is authed
     // * the "whenAuthed" argument is set to redirect to the app
     // * if on the client side, the call to set cookies has completed
+    //   (see: https://github.com/gladly-team/next-firebase-auth/issues/189)
     const shouldRedirectToApp =
       isAuthed &&
       whenAuthed === AuthAction.REDIRECT_TO_APP &&
@@ -88,6 +89,7 @@ const withAuthUser = ({
     //   Firebase has initialized
     // * the "when unauthed" settings tell us to redirect to login AFTER
     //   Firebase has initialized, and the call to set cookies has completed
+    //   (see: https://github.com/gladly-team/next-firebase-auth/issues/189)
     const shouldRedirectToLogin =
       !isAuthed &&
       ((!isInitialized &&

--- a/src/withAuthUser.js
+++ b/src/withAuthUser.js
@@ -54,7 +54,7 @@ const withAuthUser = ({
       user: firebaseUser,
       claims,
       initialized: firebaseInitialized,
-      loginRequestCompleted,
+      authRequestCompleted,
     } = useFirebaseUser()
     const AuthUserFromClient = createAuthUser({
       firebaseUserClientSDK: firebaseUser,
@@ -81,7 +81,7 @@ const withAuthUser = ({
     const willRedirectToApp =
       isAuthed && whenAuthed === AuthAction.REDIRECT_TO_APP
     const shouldRedirectToApp =
-      willRedirectToApp && isClientSide && loginRequestCompleted
+      willRedirectToApp && isClientSide && authRequestCompleted
 
     // Redirect to the login page if the user is not authed and one of these
     // is true:
@@ -102,7 +102,7 @@ const withAuthUser = ({
       // We don't have to wait for an auth request if we should redirect
       // before Firebase initializes.
       (whenUnauthedBeforeInit !== AuthAction.REDIRECT_TO_LOGIN
-        ? loginRequestCompleted
+        ? authRequestCompleted
         : true)
 
     const router = useRouter()
@@ -184,7 +184,7 @@ const withAuthUser = ({
       } else {
         returnVal = comps
       }
-    } else if (!isAuthed && !loginRequestCompleted) {
+    } else if (!isAuthed && !authRequestCompleted) {
       if (whenUnauthedBeforeInit === AuthAction.SHOW_LOADER) {
         returnVal = loaderComp
       } else if (whenUnauthedBeforeInit === AuthAction.RETURN_NULL) {


### PR DESCRIPTION
Closes #189.

This introduces UX changes that delay redirects.
* When a user is logged in and is on a static (auth) page that will redirect to the app, it will wait for the login request to complete. This library does not currently support rendering any components while waiting on a redirect to the app, so it will render null while waiting for the login request to finish. **We may want to improve this** by providing the ability to render UI while waiting on the login request.
* When a user is _not_ logged in and is on a static app page that will redirect to an auth page, it will wait for the logout request to complete. This will render the same component (null, loader, or child components) as before but for a longer time.