### PR TITLE
Use useMemo in withAuthUser to avoid an unnecessary re-render

### DIFF
--- a/src/withAuthUser.js
+++ b/src/withAuthUser.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useCallback } from 'react'
+import React, { useEffect, useCallback, useMemo } from 'react'
 import { useRouter } from 'next/router'
 import { AuthUserContext } from 'src/useAuthUser'
 import createAuthUser from 'src/createAuthUser'
@@ -49,9 +49,13 @@ const withAuthUser =
   (ChildComponent) => {
     const WithAuthUserHOC = (props) => {
       const { AuthUserSerialized, ...otherProps } = props
-      const AuthUserFromServer = createAuthUser({
-        serializedAuthUser: AuthUserSerialized,
-      })
+      const AuthUserFromServer = useMemo(
+        () =>
+          createAuthUser({
+            serializedAuthUser: AuthUserSerialized,
+          }),
+        [AuthUserSerialized]
+      )
 
       const {
         user: firebaseUser,
@@ -59,11 +63,15 @@ const withAuthUser =
         initialized: firebaseInitialized,
         authRequestCompleted,
       } = useFirebaseUser()
-      const AuthUserFromClient = createAuthUser({
-        firebaseUserClientSDK: firebaseUser,
-        clientInitialized: firebaseInitialized,
-        claims,
-      })
+      const AuthUserFromClient = useMemo(
+        () =>
+          createAuthUser({
+            firebaseUserClientSDK: firebaseUser,
+            clientInitialized: firebaseInitialized,
+            claims,
+          }),
+        [firebaseUser, firebaseInitialized, claims]
+      )
 
       // Set the AuthUser to values from the Firebase JS SDK user
       // once it has initialized. On the server side and before the


### PR DESCRIPTION
This PR can (potentially) prevent an unnecessary re-render when `useFirebaseUser` returns a new value for "authRequestCompleted", which does not affect the AuthUser value.