### PR TITLE
Support modular Firebase 9

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,22 +4,29 @@
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](./CODE_OF_CONDUCT.md)
 
 # next-firebase-auth
+
 Simple Firebase authentication for all Next.js rendering strategies.
 
-#### [Demo](#demo) • [Alternatives](#when-not-to-use-this-package) • [Getting Started](#get-started) • [API](#api) • [Config](#config) • [Types](#types) • [Examples](#examples) • [Troubleshooting](#troubleshooting) • [Contributing](./CONTRIBUTING.md)
+#### [Demo](#demo) • [Alternatives](#when-not-to-use-this-package) • [Getting Started](#get-started) • [API](#api) • [Config](#config) • [Types](#types) • [Upgrading to Firebase 9](#upgrading-to-firebase-9) • [Examples](#examples) • [Troubleshooting](#troubleshooting) • [Contributing](./CONTRIBUTING.md)
 
 ## What It Does
+
 This package makes it simple to get the authenticated Firebase user and ID token during both client-side and server-side rendering (SSR).
 
 ###### &nbsp;&nbsp;&nbsp;&nbsp; 🌍 &nbsp; Support for all Next.js rendering strategies
-######  &nbsp;&nbsp;&nbsp;&nbsp; 🔒 &nbsp; Signed, secure, HTTP-only cookies by default
+
+###### &nbsp;&nbsp;&nbsp;&nbsp; 🔒 &nbsp; Signed, secure, HTTP-only cookies by default
+
 ###### &nbsp;&nbsp;&nbsp;&nbsp; 🆔 &nbsp; Server-side access to the user's Firebase ID token
-######  &nbsp;&nbsp;&nbsp;&nbsp; 🍪 &nbsp; Built-in cookie management
+
+###### &nbsp;&nbsp;&nbsp;&nbsp; 🍪 &nbsp; Built-in cookie management
+
 ###### &nbsp;&nbsp;&nbsp;&nbsp; ↩️ &nbsp; Built-in support for redirecting based on the user's auth status
 
 We treat the Firebase JS SDK as the source of truth for auth status. When the user signs in, we call an endpoint to generate a refresh token and store the user info, ID token, and refresh token in cookies. Future requests to SSR pages receive the user info and ID token from cookies, refreshing the ID token as needed. When the user logs out, we unset the cookies.
 
 ## Demo
+
 [See a live demo](https://nfa-example-git-v1x-gladly-team.vercel.app/) of the [example app](https://github.com/gladly-team/next-firebase-auth/tree/main/example).
 
 ## When (Not) to Use this Package
@@ -27,22 +34,25 @@ We treat the Firebase JS SDK as the source of truth for auth status. When the us
 Depending on your app's needs, other approaches might work better for you.
 
 **If your app only uses static pages** or doesn't need the Firebase user for SSR, use the Firebase JS SDK directly to load the user on the client side.
-  * *Pros:* It's simpler and removes this package as a dependency.
-  * *Cons:* You will not have access to the Firebase user when you use `getServerSideProps`.
+
+- _Pros:_ It's simpler and removes this package as a dependency.
+- _Cons:_ You will not have access to the Firebase user when you use `getServerSideProps`.
 
 **If your app needs the Firebase user for SSR (but does not need the ID token server-side)**, you could consider one of these approaches:
-  1. On the client, set a JavaScript cookie with the Firebase user information once the Firebase JS SDK loads.
-      * *Pros:* You won't need login/logout API endpoints. You can structure the authed user data however you'd like.
-      * *Cons:* The cookie will be unsigned and accessible to other JavaScript, making this approach less secure. You won't always have access to the Firebase ID token server-side, so you won't be able to access other Firebase services. (Note that you can set the ID token in the cookie, but it will expire after an hour and be invalid for future server-side-rendered pages.)
-  2. Use [Firebase's session cookies](https://firebase.google.com/docs/auth/admin/manage-cookies).
-      * *Pros:* It removes this package as a dependency.
-      * *Cons:* You won't have access to the Firebase ID token server-side, so you won't be able to access other Firebase services. You'll need to implement logic for verifying the session and managing session state.
+
+1. On the client, set a JavaScript cookie with the Firebase user information once the Firebase JS SDK loads.
+   - _Pros:_ You won't need login/logout API endpoints. You can structure the authed user data however you'd like.
+   - _Cons:_ The cookie will be unsigned and accessible to other JavaScript, making this approach less secure. You won't always have access to the Firebase ID token server-side, so you won't be able to access other Firebase services. (Note that you can set the ID token in the cookie, but it will expire after an hour and be invalid for future server-side-rendered pages.)
+2. Use [Firebase's session cookies](https://firebase.google.com/docs/auth/admin/manage-cookies).
+   - _Pros:_ It removes this package as a dependency.
+   - _Cons:_ You won't have access to the Firebase ID token server-side, so you won't be able to access other Firebase services. You'll need to implement logic for verifying the session and managing session state.
 
 **This package will likely be helpful** if you expect to use both static pages and SSR or if you need access to Firebase ID tokens server-side.
 
 > A quick note on what this package does _not_ do:
-> * It does not provide authentication UI. Consider [firebasesui-web](https://github.com/firebase/firebaseui-web) or build your own.
-> * It does not extend Firebase functionality beyond providing universal access to the authed user. Use the Firebase admin SDK and Firebase JS SDK for any other needs.
+>
+> - It does not provide authentication UI. Consider [firebasesui-web](https://github.com/firebase/firebaseui-web) or build your own.
+> - It does not extend Firebase functionality beyond providing universal access to the authed user. Use the Firebase admin SDK and Firebase JS SDK for any other needs.
 
 ## Get Started
 
@@ -107,12 +117,12 @@ const initAuth = () => {
 }
 
 export default initAuth
-
 ```
 
 Set the private environment variables `FIREBASE_PRIVATE_KEY`, `COOKIE_SECRET_CURRENT`, and `COOKIE_SECRET_PREVIOUS` in `.env.local`. If you have enabled [the Firebase Authentication Emulator](#https://firebase.google.com/docs/emulator-suite/connect_auth), you will also need to set the `FIREBASE_AUTH_EMULATOR_HOST` environment variable.
 
 Initialize `next-firebase-auth` in `_app.js`:
+
 ```js
 // ./pages/_app.js
 import initAuth from '../initAuth' // the module you created above
@@ -124,7 +134,6 @@ function MyApp({ Component, pageProps }) {
 }
 
 export default MyApp
-
 ```
 
 Create login and logout API endpoints that set auth cookies:
@@ -182,7 +191,7 @@ const Demo = () => {
   const AuthUser = useAuthUser()
   return (
     <div>
-      <p>Your email is {AuthUser.email ? AuthUser.email : "unknown"}.</p>
+      <p>Your email is {AuthUser.email ? AuthUser.email : 'unknown'}.</p>
     </div>
   )
 }
@@ -195,18 +204,19 @@ export default withAuthUser()(Demo)
 
 ## API
 
-* [init](#initconfig)
-* [withAuthUser](#withauthuser-options-pagecomponent)
-* [withAuthUserTokenSSR](#withauthusertokenssr-options-getserversidepropsfunc---authuser---)
-* [withAuthUserSSR](#withauthuserssr-options-getserversidepropsfunc---authuser---)
-* [useAuthUser](#useauthuser)
-* [setAuthCookies](#setauthcookiesreq-res)
-* [unsetAuthCookies](#unsetauthcookiesreq-res)
-* [verifyIdToken](#verifyidtokentoken--promiseauthuser)
-* [AuthAction](#authaction)
-* [getFirebaseAdmin](#getfirebaseadmin--firebaseadmin)
+- [init](#initconfig)
+- [withAuthUser](#withauthuser-options-pagecomponent)
+- [withAuthUserTokenSSR](#withauthusertokenssr-options-getserversidepropsfunc---authuser---)
+- [withAuthUserSSR](#withauthuserssr-options-getserversidepropsfunc---authuser---)
+- [useAuthUser](#useauthuser)
+- [setAuthCookies](#setauthcookiesreq-res)
+- [unsetAuthCookies](#unsetauthcookiesreq-res)
+- [verifyIdToken](#verifyidtokentoken--promiseauthuser)
+- [AuthAction](#authaction)
+- [getFirebaseAdmin](#getfirebaseadmin--firebaseadmin)
 
------
+---
+
 #### `init(config)`
 
 Initializes `next-firebase-auth`, taking a [config](#config) object. **Must be called** before calling any other method.
@@ -217,16 +227,17 @@ A higher-order function to provide the `AuthUser` context to a component. Use th
 
 It accepts the following options:
 
-Option | Description | Default
------------- | ------------- | -------------
-`whenAuthed` | The action to take if the user is authenticated. One of `AuthAction.RENDER` or `AuthAction.REDIRECT_TO_APP`. | `AuthAction.RENDER`
-`whenUnauthedBeforeInit` | The action to take if the user is *not* authenticated but the Firebase client JS SDK has not yet initialized. One of: `AuthAction.RENDER`, `AuthAction.REDIRECT_TO_LOGIN`, `AuthAction.SHOW_LOADER`. | `AuthAction.RENDER`
-`whenUnauthedAfterInit` | The action to take if the user is *not* authenticated and the Firebase client JS SDK has already initialized. One of: `AuthAction.RENDER`, `AuthAction.REDIRECT_TO_LOGIN`. | `AuthAction.RENDER`
-`appPageURL` | The redirect destination URL when we should redirect to the app. Can be a string or a function that receives `{ ctx }` and returns a URL. | `config.appPageURL`
-`authPageURL` | The redirect destination URL when we should redirect to the login page. Can be a string or a function that receives `{ ctx }` and returns a URL. | `config.authPageURL`
-`LoaderComponent` | The component to render when the user is unauthed and `whenUnauthedBeforeInit` is set to `AuthAction.SHOW_LOADER`. | null
+| Option                   | Description                                                                                                                                                                                          | Default              |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------- |
+| `whenAuthed`             | The action to take if the user is authenticated. One of `AuthAction.RENDER` or `AuthAction.REDIRECT_TO_APP`.                                                                                         | `AuthAction.RENDER`  |
+| `whenUnauthedBeforeInit` | The action to take if the user is _not_ authenticated but the Firebase client JS SDK has not yet initialized. One of: `AuthAction.RENDER`, `AuthAction.REDIRECT_TO_LOGIN`, `AuthAction.SHOW_LOADER`. | `AuthAction.RENDER`  |
+| `whenUnauthedAfterInit`  | The action to take if the user is _not_ authenticated and the Firebase client JS SDK has already initialized. One of: `AuthAction.RENDER`, `AuthAction.REDIRECT_TO_LOGIN`.                           | `AuthAction.RENDER`  |
+| `appPageURL`             | The redirect destination URL when we should redirect to the app. Can be a string or a function that receives `{ ctx }` and returns a URL.                                                            | `config.appPageURL`  |
+| `authPageURL`            | The redirect destination URL when we should redirect to the login page. Can be a string or a function that receives `{ ctx }` and returns a URL.                                                     | `config.authPageURL` |
+| `LoaderComponent`        | The component to render when the user is unauthed and `whenUnauthedBeforeInit` is set to `AuthAction.SHOW_LOADER`.                                                                                   | null                 |
 
 For example, this page will redirect to the login page if the user is not authenticated:
+
 ```jsx
 import { withAuthUser, AuthAction } from 'next-firebase-auth'
 
@@ -234,11 +245,12 @@ const DemoPage = () => <div>My demo page</div>
 
 export default withAuthUser({
   whenUnauthedAfterInit: AuthAction.REDIRECT_TO_LOGIN,
-  authPageURL: '/my-login-page/'
+  authPageURL: '/my-login-page/',
 })(DemoPage)
 ```
 
 Here's an example of a login page that shows a loader until Firebase is initialized, then redirects to the app if the user is already logged in:
+
 ```jsx
 import { withAuthUser, AuthAction } from 'next-firebase-auth'
 
@@ -262,13 +274,12 @@ A higher-order function that wraps a Next.js pages's `getServerSideProps` functi
 
 It accepts the following options:
 
-Option | Description | Default
------------- | ------------- | -------------
-`whenAuthed` | The action to take if the user is authenticated. Either `AuthAction.RENDER` or `AuthAction.REDIRECT_TO_APP`. | `AuthAction.RENDER`
-`whenUnauthed` | The action to take if the user is *not* authenticated. Either `AuthAction.RENDER` or `AuthAction.REDIRECT_TO_LOGIN`. | `AuthAction.RENDER`
-`appPageURL` | The redirect destination URL when we should redirect to the app. Can be a string or a function that receives `{ ctx }` and returns a URL. | `config.appPageURL`
-`authPageURL` | The redirect destination URL when we should redirect to the login page. Can be a string or a function that receives `{ ctx }` and returns a URL. | `config.authPageURL`
-
+| Option         | Description                                                                                                                                      | Default              |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------- |
+| `whenAuthed`   | The action to take if the user is authenticated. Either `AuthAction.RENDER` or `AuthAction.REDIRECT_TO_APP`.                                     | `AuthAction.RENDER`  |
+| `whenUnauthed` | The action to take if the user is _not_ authenticated. Either `AuthAction.RENDER` or `AuthAction.REDIRECT_TO_LOGIN`.                             | `AuthAction.RENDER`  |
+| `appPageURL`   | The redirect destination URL when we should redirect to the app. Can be a string or a function that receives `{ ctx }` and returns a URL.        | `config.appPageURL`  |
+| `authPageURL`  | The redirect destination URL when we should redirect to the login page. Can be a string or a function that receives `{ ctx }` and returns a URL. | `config.authPageURL` |
 
 For example, this page will SSR for authenticated users, fetching props using their Firebase ID token, and will server-side redirect to the login page if the user is not authenticated:
 
@@ -291,8 +302,8 @@ export const getServerSideProps = withAuthUserTokenSSR({
   const data = await response.json()
   return {
     props: {
-      thing: data.thing
-    }
+      thing: data.thing,
+    },
   }
 })
 
@@ -302,9 +313,10 @@ export default withAuthUser()(DemoPage)
 #### `withAuthUserSSR({ ...options })(getServerSidePropsFunc = ({ AuthUser }) => {})`
 
 Behaves nearly identically to `withAuthUserTokenSSR`, with one key difference: it does not validate an ID token. Instead, it simply uses the `AuthUser` data from a cookie. Consequently:
-* It does not provide an ID token on the server side. The `AuthUser` provided via context will resolve to null when you call `AuthUser.getIdToken()`.
-* It does not need to make a network request to refresh an expired ID token, so it will, on average, be faster than `withAuthUserTokenSSR`.
-* It does *not* check for token revocation. If you need verification that the user's credentials haven't been revoked, you should always use `withAuthUserTokenSSR`.
+
+- It does not provide an ID token on the server side. The `AuthUser` provided via context will resolve to null when you call `AuthUser.getIdToken()`.
+- It does not need to make a network request to refresh an expired ID token, so it will, on average, be faster than `withAuthUserTokenSSR`.
+- It does _not_ check for token revocation. If you need verification that the user's credentials haven't been revoked, you should always use `withAuthUserTokenSSR`.
 
 ⚠️ Do not use this when `cookies.signed` is set to `false`. Doing so is a potential security risk, because the authed user cookie values could be modified by the client.
 
@@ -323,7 +335,7 @@ const Demo = () => {
   const AuthUser = useAuthUser()
   return (
     <div>
-      <p>Your email is {AuthUser.email ? AuthUser.email : "unknown"}.</p>
+      <p>Your email is {AuthUser.email ? AuthUser.email : 'unknown'}.</p>
     </div>
   )
 }
@@ -366,14 +378,17 @@ A convenience function that returns the configured Firebase admin module.
 This can only be called from the server side. It will throw an error if called from the client side.
 
 For example:
-````jsx
+
+```jsx
 import { getFirebaseAdmin } from 'next-firebase-auth'
 // ...other imports
 
-const Artist = ({artists}) => {
+const Artist = ({ artists }) => {
   return (
     <ul>
-      {artists.map((artist) => <li>{artist.name}</li>)} 
+      {artists.map((artist) => (
+        <li>{artist.name}</li>
+      ))}
     </ul>
   )
 }
@@ -384,14 +399,14 @@ export async function getServerSideProps({ params: { id } }) {
   return {
     props: {
       artists: artists.docs.map((a) => {
-       return { ...a.data(), key: a.id }
+        return { ...a.data(), key: a.id }
       }),
-    }
+    },
   }
 }
 
 export default withAuthUser()(Artist)
-````
+```
 
 ## Config
 
@@ -408,6 +423,7 @@ See an [example config here](#example-config). Provide the config when you call 
 **tokenChangedHandler**: A callback that runs when the auth state changes for a particular user. Use this if you want to customize how your client-side app calls your login/logout API endpoints (for example, to use a custom fetcher or add custom headers). `tokenChangedHandler` receives an `AuthUser` as an argument and is called when the user's ID token changes, similarly to Firebase's `onIdTokenChanged` event.
 
 If this callback is specified, user is responsible for:
+
 1. Calling their login/logout endpoints depending on the user's auth state.
 2. Passing the user's ID token in the Authorization header
 3. Ensuring it allows the request to set cookies.
@@ -424,17 +440,17 @@ Configuration passed to `firebase-admin`'s [`initializeApp`](https://firebase.go
 
 The `firebaseAdminInitConfig.credential.privateKey` cannot be defined on the client side and should live in a secret environment variable.
 
-> Note: if using environent variables in Vercel, add the private key *with double quotes* via the CLI:
+> Note: if using environent variables in Vercel, add the private key _with double quotes_ via the CLI:
 >
->   `vercel secrets add firebase-private-key '"my-key-here"'`
+> `vercel secrets add firebase-private-key '"my-key-here"'`
 >
 > Then, use `JSON.parse` in the `firebaseAdminInitConfig.credential.privateKey` property:
 >
->    ```
->      privateKey: process.env.FIREBASE_PRIVATE_KEY
->        ? JSON.parse(process.env.FIREBASE_PRIVATE_KEY)
->        : undefined
->    ```
+> ```
+>   privateKey: process.env.FIREBASE_PRIVATE_KEY
+>     ? JSON.parse(process.env.FIREBASE_PRIVATE_KEY)
+>     : undefined
+> ```
 >
 > See [this Vercel issue](https://github.com/vercel/vercel/issues/749#issuecomment-707515089) for more information.
 
@@ -445,9 +461,10 @@ The `firebaseAdminInitConfig.credential.privateKey` cannot be defined on the cli
 Settings used for auth cookies. We use [`cookies`](https://github.com/pillarjs/cookies) to manage cookies.
 
 Properties include:
-* `name`: Used as a base for cookie names: if `name` is set to "MyExample", cookies will be named `MyExample.AuthUser` and `MyExample.AuthUserTokens` (plus `MyExample.AuthUser.sig` and `MyExample.AuthUserTokens.sig` if cookies are signed). **Required.**
-* `keys`: An array of strings that will be used to sign cookies; for instance, `['xD$WVv3qrP3ywY', '2x6#msoUeNhVHr']`. As these strings are secrets, provide them via secret environment variables, such as `[ process.env.COOKIE_SECRET_CURRENT, process.env.COOKIE_SECRET_PREVIOUS ]`. The `keys` array is passed to the [Keygrip](https://www.npmjs.com/package/keygrip) constructor as described in [the `cookies` package](https://github.com/pillarjs/cookies#cookies--new-cookies-request-response--options--). **Required** unless `signed` is set to `false`.
-* [All options for `cookies.set`](https://github.com/pillarjs/cookies#cookiesset-name--value---options--).
+
+- `name`: Used as a base for cookie names: if `name` is set to "MyExample", cookies will be named `MyExample.AuthUser` and `MyExample.AuthUserTokens` (plus `MyExample.AuthUser.sig` and `MyExample.AuthUserTokens.sig` if cookies are signed). **Required.**
+- `keys`: An array of strings that will be used to sign cookies; for instance, `['xD$WVv3qrP3ywY', '2x6#msoUeNhVHr']`. As these strings are secrets, provide them via secret environment variables, such as `[ process.env.COOKIE_SECRET_CURRENT, process.env.COOKIE_SECRET_PREVIOUS ]`. The `keys` array is passed to the [Keygrip](https://www.npmjs.com/package/keygrip) constructor as described in [the `cookies` package](https://github.com/pillarjs/cookies#cookies--new-cookies-request-response--options--). **Required** unless `signed` is set to `false`.
+- [All options for `cookies.set`](https://github.com/pillarjs/cookies#cookiesset-name--value---options--).
 
 The `keys` value cannot be defined on the client side and should live in a secret environment variable.
 
@@ -529,11 +546,52 @@ The user from the Firebase JS SDK, if it has initialized. Otherwise, null.
 
 A method that calls Firebase's [`signOut`](https://firebase.google.com/docs/reference/js/firebase.auth.Auth#signout) if the Firebase JS SDK has initialized. If the SDK has not initialized, this method is a noop.
 
+## Upgrading to Firebase 9
+
+Firebase 9 has a new API surface designed to facilitate tree-shaking (removal of unused code) to make your web app as small and fast as possible.
+
+If you were previously using version 7 of 8 of the SDK you can easily upgrade by following the [official guide](https://firebase.google.com/docs/web/modular-upgrade).
+
+Here is an example of how the migration might look in your app:
+
+```diff
+-import firebase from 'firebase/app'
+-import 'firebase/firestore'
++import { getApp } from 'firebase/app'
++import { getFirestore, collection, onSnapshot } from 'firebase/firestore'
+ import { useEffect } from 'react'
+
+ const Artists = () => {
+   const [artists, setArtists] = useState(artists)
+
+   useEffect(() => {
+-    return firebase.firestore()
+-      .collection('artists')
+-      .onSnapshot((snap) => {
++    return onSnapshot(collection(getFirestore(getApp()), 'artists'), (snap) => {
+       if (!snap) {
+         return
+       }
+       setArtists(snap.docs.map((doc) => ({ ...doc.data(), key: doc.id })))
+     })
+   }, [])
+
+   return (
+     <div>
+       {artists.map((artist) => (
+         <div>{artist.name}</div>
+       ))}
+     </div>
+   )
+ }
+```
+
 ## Examples
-* [Using the Firebase Apps](#using-the-firebase-apps)
-* [TypeScript](#typescript)
-* [Dynamic Redirects](#dynamic-redirects)
-* [Testing and Mocking with Jest](#testing-and-mocking-with-jest)
+
+- [Using the Firebase Apps](#using-the-firebase-apps)
+- [TypeScript](#typescript)
+- [Dynamic Redirects](#dynamic-redirects)
+- [Testing and Mocking with Jest](#testing-and-mocking-with-jest)
 
 ### Using the Firebase Apps
 
@@ -544,34 +602,31 @@ To use the Firebase admin module, you can use [`getFirebaseAdmin`](#getfirebasea
 To use the Firebase JS SDK, simply import Firebase as you normally would. For example:
 
 ```jsx
-import firebase from 'firebase/app'
-import 'firebase/firestore'
-import { useEffect } from "react"
+import { getApp } from 'firebase/app'
+import { getFirestore, collection, onSnapshot } from 'firebase/firestore'
+import { useEffect } from 'react'
 
 const Artists = () => {
   const [artists, setArtists] = useState(artists)
-  
+
   useEffect(() => {
-    return firebase.firestore()
-      .collection('artists')
-      .onSnapshot( (snap) => {
-        if (!snap) {
-          return
-        }
-        setArtists(snap.docs.map(doc => ({ ...doc.data(), key: doc.id })))
-        
-      })
-  }, []);
-  
+    return onSnapshot(collection(getFirestore(getApp()), 'artists'), (snap) => {
+      if (!snap) {
+        return
+      }
+      setArtists(snap.docs.map((doc) => ({ ...doc.data(), key: doc.id })))
+    })
+  }, [])
+
   return (
     <div>
-      {artists.map((artist) => <div>{artist.name}</div>)}
+      {artists.map((artist) => (
+        <div>{artist.name}</div>
+      ))}
     </div>
   )
-  
 }
 ```
-
 
 ### TypeScript
 
@@ -750,9 +805,7 @@ import { useAuthUser, withAuthUser } from 'next-firebase-auth'
 function UserDisplayName() {
   const AuthUser = useAuthUser()
   const { displayName = 'anonymous' } = AuthUser.firebaseUser
-  return (
-    <span>{displayName}</span>
-  )
+  return <span>{displayName}</span>
 }
 
 export default withAuthUser()(UserDisplayName)
@@ -775,7 +828,7 @@ import getMockAuthUser from '../../utils/test-utils/get-mock-auth-user'
 // because Jest will automatically mock the module in every test.
 jest.mock('next-firebase-auth')
 
-describe('UserDisplayName', () => { 
+describe('UserDisplayName', () => {
 
   // Create a placeholder for your component that you want to test
   let UserDisplayName
@@ -827,7 +880,7 @@ import { useAuthUser, withAuthUser } from 'next-firebase-auth'
 import getMockAuthUser from '../../utils/test-utils/get-mock-auth-user'
 
 // Mock all of `next-firebase-auth`. This is *not* necessary if you set up manual mocks,
-// because Jest will automatically mock the module 
+// because Jest will automatically mock the module
 jest.mock('next-firebase-auth')
 
 describe('UserDisplayName', () => {
@@ -895,8 +948,8 @@ In addition, please double-check your server logs for any errors to ensure the F
 
 We expect some apps will need some features that are not currently available:
 
-* **Supporting custom session logic:** Currently, this package doesn't allow using a custom cookie or session module. Some developers may need this flexibility to, for example, keep auth user data in server-side session storage.
-* **Setting a single auth cookie:** This package currently sets more than one cookie to store authentication state. It's not currently possible to use a single cookie with a customized name: [#190](https://github.com/gladly-team/next-firebase-auth/issues/190)
+- **Supporting custom session logic:** Currently, this package doesn't allow using a custom cookie or session module. Some developers may need this flexibility to, for example, keep auth user data in server-side session storage.
+- **Setting a single auth cookie:** This package currently sets more than one cookie to store authentication state. It's not currently possible to use a single cookie with a customized name: [#190](https://github.com/gladly-team/next-firebase-auth/issues/190)
 
 We'd love to hear your feedback on these or other features. Please feel free to [open a discussion](https://github.com/gladly-team/next-firebase-auth/discussions)!
 

--- a/__mocks__/firebase/app.js
+++ b/__mocks__/firebase/app.js
@@ -1,13 +1,5 @@
-const firebaseAppMock = jest.createMockFromModule('firebase')
-firebaseAppMock.apps = []
+const firebaseAppMock = jest.createMockFromModule('firebase/app')
 
-const mockOnIdTokenChangedUnsubscribe = jest.fn()
-const mockOnIdTokenChanged = jest.fn(() => mockOnIdTokenChangedUnsubscribe)
-const mockSignOut = jest.fn(() => Promise.resolve())
-
-firebaseAppMock.auth = jest.fn(() => ({
-  onIdTokenChanged: mockOnIdTokenChanged,
-  signOut: mockSignOut,
-}))
+firebaseAppMock.getApps = jest.fn(() => [])
 
 module.exports = firebaseAppMock

--- a/__mocks__/firebase/auth.js
+++ b/__mocks__/firebase/auth.js
@@ -1,1 +1,10 @@
-module.exports = jest.fn()
+const firebaseAuthMock = jest.createMockFromModule('firebase/auth')
+
+const mockOnIdTokenChangedUnsubscribe = jest.fn()
+const mockOnIdTokenChanged = jest.fn(() => mockOnIdTokenChangedUnsubscribe)
+const mockSignOut = jest.fn(() => Promise.resolve())
+
+firebaseAuthMock.onIdTokenChanged = mockOnIdTokenChanged
+firebaseAuthMock.signOut = mockSignOut
+
+module.exports = firebaseAuthMock

--- a/example/components/FirebaseAuth.js
+++ b/example/components/FirebaseAuth.js
@@ -1,8 +1,8 @@
 /* globals window */
 import React, { useEffect, useState } from 'react'
 import StyledFirebaseAuth from 'react-firebaseui/StyledFirebaseAuth'
-import firebase from 'firebase/app'
-import 'firebase/auth'
+import { getApp } from 'firebase/app'
+import { getAuth, EmailAuthProvider } from 'firebase/auth'
 
 // Note that next-firebase-auth inits Firebase for us,
 // so we don't need to.
@@ -13,7 +13,7 @@ const firebaseAuthConfig = {
   // https://github.com/firebase/firebaseui-web#configure-oauth-providers
   signInOptions: [
     {
-      provider: firebase.auth.EmailAuthProvider.PROVIDER_ID,
+      provider: EmailAuthProvider.PROVIDER_ID,
       requireDisplayName: false,
     },
   ],
@@ -42,7 +42,7 @@ const FirebaseAuth = () => {
       {renderAuth ? (
         <StyledFirebaseAuth
           uiConfig={firebaseAuthConfig}
-          firebaseAuth={firebase.auth()}
+          firebaseAuth={getAuth(getApp())}
         />
       ) : null}
     </div>

--- a/example/package.json
+++ b/example/package.json
@@ -9,7 +9,7 @@
     "deploy": "vercel --prod"
   },
   "dependencies": {
-    "firebase": "^8.9.1",
+    "firebase": "^9.0.0",
     "firebase-admin": "^9.11.0",
     "next": "11.1.0",
     "next-absolute-url": "^1.2.2",

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 import * as Cookies from 'cookies'
-import type Firebase from 'firebase'
+import type { User } from 'firebase/auth'
 import * as firebaseAdmin from 'firebase-admin'
 import type {
   GetServerSidePropsContext,
@@ -28,7 +28,7 @@ export interface AuthUser {
   claims: Record<string, string | boolean>
   getIdToken: () => Promise<string | null>
   clientInitialized: boolean
-  firebaseUser: Firebase.User | null
+  firebaseUser: User | null
   signOut: () => Promise<void>
 }
 

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "eslint-plugin-prettier": "^3.3.0",
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-react-hooks": "^4.2.0",
-    "firebase": "^8.8.1",
+    "firebase": "^9.0.0",
     "firebase-admin": "^9.11.0",
     "jest": "^27.0.6",
     "jsdom": "^16.7.0",
@@ -80,7 +80,7 @@
     "webpack-node-externals": "^3.0.0"
   },
   "peerDependencies": {
-    "firebase": ">=7.0.0 <9",
+    "firebase": "^9.0.0",
     "firebase-admin": "^9.0.0",
     "next": ">=9.5.0 <12",
     "react": ">=16.8.0 <18",

--- a/src/__tests__/createAuthUser.test.js
+++ b/src/__tests__/createAuthUser.test.js
@@ -1,4 +1,4 @@
-import firebase from 'firebase/app'
+import { signOut } from 'firebase/auth'
 import {
   createMockFirebaseUserClientSDK,
   createMockFirebaseUserAdminSDK,
@@ -222,7 +222,7 @@ describe('createAuthUser: firebaseUserClientSDK', () => {
       firebaseUserClientSDK: createMockFirebaseUserClientSDK(),
     })
     await AuthUser.signOut()
-    expect(firebase.auth().signOut).toHaveBeenCalled()
+    expect(signOut).toHaveBeenCalled()
   })
 
   it("does not call Firebase's signOut method when we call AuthUser.signOut and the user is unauthed", async () => {
@@ -232,7 +232,7 @@ describe('createAuthUser: firebaseUserClientSDK', () => {
       firebaseUserClientSDK: null,
     })
     await AuthUser.signOut()
-    expect(firebase.auth().signOut).not.toHaveBeenCalled()
+    expect(signOut).not.toHaveBeenCalled()
   })
 })
 
@@ -427,7 +427,7 @@ describe('createAuthUser: firebaseUserAdminSDK', () => {
       token: 'my-id-token-def-456',
     })
     await AuthUser.signOut()
-    expect(firebase.auth().signOut).not.toHaveBeenCalled()
+    expect(signOut).not.toHaveBeenCalled()
   })
 })
 
@@ -518,6 +518,6 @@ describe('createAuthUser: serializedAuthUser', () => {
       serializedAuthUser: createMockSerializedAuthUser(),
     })
     await AuthUser.signOut()
-    expect(firebase.auth().signOut).not.toHaveBeenCalled()
+    expect(signOut).not.toHaveBeenCalled()
   })
 })

--- a/src/__tests__/useFirebaseUser.test.js
+++ b/src/__tests__/useFirebaseUser.test.js
@@ -1,4 +1,4 @@
-import firebase from 'firebase/app'
+import { getIdTokenResult, onIdTokenChanged } from 'firebase/auth'
 import { renderHook, act } from '@testing-library/react-hooks'
 import useFirebaseUser from 'src/useFirebaseUser'
 import {
@@ -11,8 +11,8 @@ import createMockConfig from 'src/testHelpers/createMockConfig'
 import createAuthUser from 'src/createAuthUser'
 import logDebug from 'src/logDebug'
 
-jest.mock('firebase/auth')
 jest.mock('firebase/app')
+jest.mock('firebase/auth')
 jest.mock('src/config')
 jest.mock('src/logDebug')
 
@@ -52,18 +52,13 @@ describe('useFirebaseUser', () => {
     let onIdTokenChangedCallback
 
     // Capture the onIdTokenChanged callback
-    const onIdTokenChanged = jest.fn((callback) => {
+    onIdTokenChanged.mockImplementation((_, callback) => {
       onIdTokenChangedCallback = callback
       return () => {} // "unsubscribe" function
     })
 
     // Intercept the getIdToken call
-    const getIdTokenResult = jest.fn(async () => mockFirebaseUserWithClaims)
-
-    jest.spyOn(firebase, 'auth').mockImplementation(() => ({
-      currentUser: { getIdTokenResult },
-      onIdTokenChanged,
-    }))
+    getIdTokenResult.mockResolvedValue(mockFirebaseUserWithClaims)
 
     const { result } = renderHook(() => useFirebaseUser())
 
@@ -87,18 +82,13 @@ describe('useFirebaseUser', () => {
     let onIdTokenChangedCallback
 
     // Capture the onIdTokenChanged callback
-    const onIdTokenChanged = jest.fn((callback) => {
+    onIdTokenChanged.mockImplementation((_, callback) => {
       onIdTokenChangedCallback = callback
       return () => {} // "unsubscribe" function
     })
 
     // Intercept the getIdToken call
-    const getIdTokenResult = jest.fn(async () => undefined)
-
-    jest.spyOn(firebase, 'auth').mockImplementation(() => ({
-      currentUser: { getIdTokenResult },
-      onIdTokenChanged,
-    }))
+    getIdTokenResult.mockResolvedValue(undefined)
 
     const { result } = renderHook(() => useFirebaseUser())
 
@@ -130,18 +120,13 @@ describe('useFirebaseUser', () => {
     let onIdTokenChangedCallback
 
     // Capture the onIdTokenChanged callback
-    const onIdTokenChanged = jest.fn((callback) => {
+    onIdTokenChanged.mockImplementation((_, callback) => {
       onIdTokenChangedCallback = callback
       return () => {} // "unsubscribe" function
     })
 
     // Intercept the getIdToken call
-    const getIdTokenResult = jest.fn(async () => mockFirebaseUserWithClaims)
-
-    jest.spyOn(firebase, 'auth').mockImplementation(() => ({
-      currentUser: { getIdTokenResult },
-      onIdTokenChanged,
-    }))
+    getIdTokenResult.mockResolvedValue(mockFirebaseUserWithClaims)
 
     const { result } = renderHook(() => useFirebaseUser())
 
@@ -170,20 +155,16 @@ describe('useFirebaseUser', () => {
     }
 
     let onIdTokenChangedCallback
+
     // Capture the onIdTokenChanged callback
-    const onIdTokenChanged = jest.fn((callback) => {
+    onIdTokenChanged.mockImplementation((_, callback) => {
       onIdTokenChangedCallback = callback
       return () => {} // "unsubscribe" function
     })
 
     // Intercept the getIdToken call
     const idTokenResult = createMockIdTokenResult()
-    const getIdTokenResult = jest.fn(async () => idTokenResult)
-
-    jest.spyOn(firebase, 'auth').mockImplementation(() => ({
-      currentUser: { getIdTokenResult },
-      onIdTokenChanged,
-    }))
+    getIdTokenResult.mockResolvedValue(idTokenResult)
 
     renderHook(() => useFirebaseUser())
 
@@ -206,22 +187,13 @@ describe('useFirebaseUser', () => {
   it('calls the logout endpoint as expected when the Firebase JS SDK calls `onIdTokenChanged` without an authed user', async () => {
     expect.assertions(2)
     let onIdTokenChangedCallback
-    const onIdTokenChanged = jest.fn((callback) => {
+
+    // Capture the onIdTokenChanged callback
+    onIdTokenChanged.mockImplementation((_, callback) => {
       onIdTokenChangedCallback = callback
       return () => {} // "unsubscribe" function
     })
 
-    // Intercept the getIdToken call
-    const getIdTokenResult = jest.fn()
-
-    jest.spyOn(firebase, 'auth').mockImplementation(() => ({
-      currentUser: { getIdTokenResult },
-      onIdTokenChanged,
-    }))
-    firebase.auth().onIdTokenChanged.mockImplementation((callback) => {
-      onIdTokenChangedCallback = callback
-      return () => {} // "unsubscribe" function
-    })
     const mockFirebaseUser = undefined
     renderHook(() => useFirebaseUser())
 
@@ -241,17 +213,15 @@ describe('useFirebaseUser', () => {
   it('throws if `fetch`ing the login endpoint does not return an OK response', async () => {
     expect.assertions(1)
     let onIdTokenChangedCallback
-    const onIdTokenChanged = jest.fn((callback) => {
+
+    // Capture the onIdTokenChanged callback
+    onIdTokenChanged.mockImplementation((_, callback) => {
       onIdTokenChangedCallback = callback
       return () => {} // "unsubscribe" function
     })
 
     const idTokenResult = createMockIdTokenResult()
-    const getIdTokenResult = jest.fn(async () => idTokenResult)
-    jest.spyOn(firebase, 'auth').mockImplementation(() => ({
-      currentUser: { getIdTokenResult },
-      onIdTokenChanged,
-    }))
+    getIdTokenResult.mockResolvedValue(idTokenResult)
 
     const mockFirebaseUser = createMockFirebaseUserClientSDK()
     renderHook(() => useFirebaseUser())
@@ -273,10 +243,13 @@ describe('useFirebaseUser', () => {
   it('throws if `fetch` throws when calling the login endpoint', async () => {
     expect.assertions(1)
     let onIdTokenChangedCallback
-    firebase.auth().onIdTokenChanged.mockImplementation((callback) => {
+
+    // Capture the onIdTokenChanged callback
+    onIdTokenChanged.mockImplementation((_, callback) => {
       onIdTokenChangedCallback = callback
       return () => {} // "unsubscribe" function
     })
+
     const mockFirebaseUser = createMockFirebaseUserClientSDK()
     renderHook(() => useFirebaseUser())
 
@@ -293,10 +266,13 @@ describe('useFirebaseUser', () => {
   it('throws if `fetch`ing the logout endpoint does not return an OK response', async () => {
     expect.assertions(1)
     let onIdTokenChangedCallback
-    firebase.auth().onIdTokenChanged.mockImplementation((callback) => {
+
+    // Capture the onIdTokenChanged callback
+    onIdTokenChanged.mockImplementation((_, callback) => {
       onIdTokenChangedCallback = callback
       return () => {} // "unsubscribe" function
     })
+
     const mockFirebaseUser = undefined
     renderHook(() => useFirebaseUser())
 
@@ -317,10 +293,13 @@ describe('useFirebaseUser', () => {
   it('throws if `fetch` throws when calling the logout endpoint', async () => {
     expect.assertions(1)
     let onIdTokenChangedCallback
-    firebase.auth().onIdTokenChanged.mockImplementation((callback) => {
+
+    // Capture the onIdTokenChanged callback
+    onIdTokenChanged.mockImplementation((_, callback) => {
       onIdTokenChangedCallback = callback
       return () => {} // "unsubscribe" function
     })
+
     const mockFirebaseUser = undefined
     renderHook(() => useFirebaseUser())
 
@@ -337,9 +316,7 @@ describe('useFirebaseUser', () => {
   it('unsubscribes from the Firebase `onIdTokenChanged` event when it unmounts', () => {
     expect.assertions(2)
     const onIdTokenChangedUnsubscribe = jest.fn()
-    firebase
-      .auth()
-      .onIdTokenChanged.mockImplementation(() => onIdTokenChangedUnsubscribe)
+    onIdTokenChanged.mockImplementation(() => onIdTokenChangedUnsubscribe)
     const { unmount } = renderHook(() => useFirebaseUser())
     expect(onIdTokenChangedUnsubscribe).not.toHaveBeenCalled()
     unmount()
@@ -369,18 +346,13 @@ describe('useFirebaseUser', () => {
     let onIdTokenChangedCallback
 
     // Capture the onIdTokenChanged callback
-    const onIdTokenChanged = jest.fn((callback) => {
+    onIdTokenChanged.mockImplementation((_, callback) => {
       onIdTokenChangedCallback = callback
       return () => {} // "unsubscribe" function
     })
 
     // Intercept the getIdToken call
-    const getIdTokenResult = jest.fn(async () => mockFirebaseUserWithClaims)
-
-    jest.spyOn(firebase, 'auth').mockImplementation(() => ({
-      currentUser: { getIdTokenResult },
-      onIdTokenChanged,
-    }))
+    getIdTokenResult.mockResolvedValue(mockFirebaseUserWithClaims)
 
     const { unmount } = renderHook(() => useFirebaseUser())
     await act(async () => {
@@ -409,18 +381,15 @@ describe('useFirebaseUser', () => {
 
     // Intercept the getIdToken call
     const idTokenResult = createMockIdTokenResult()
-    const getIdTokenResult = jest.fn(async () => idTokenResult)
+    getIdTokenResult.mockResolvedValue(idTokenResult)
 
     let onIdTokenChangedCallback
+
     // Capture the onIdTokenChanged callback
-    const onIdTokenChanged = jest.fn((callback) => {
+    onIdTokenChanged.mockImplementation((_, callback) => {
       onIdTokenChangedCallback = callback
       return () => {} // "unsubscribe" function
     })
-    jest.spyOn(firebase, 'auth').mockImplementation(() => ({
-      currentUser: { getIdTokenResult },
-      onIdTokenChanged,
-    }))
 
     const mockAuthUser = createAuthUser({
       firebaseUserClientSDK: mockFirebaseUser,
@@ -462,18 +431,13 @@ describe('useFirebaseUser', () => {
     let onIdTokenChangedCallback
 
     // Capture the onIdTokenChanged callback
-    const onIdTokenChanged = jest.fn((callback) => {
+    onIdTokenChanged.mockImplementation((_, callback) => {
       onIdTokenChangedCallback = callback
       return () => {} // "unsubscribe" function
     })
 
     // Intercept the getIdToken call
-    const getIdTokenResult = jest.fn(async () => mockFirebaseUserWithClaims)
-
-    jest.spyOn(firebase, 'auth').mockImplementation(() => ({
-      currentUser: { getIdTokenResult },
-      onIdTokenChanged,
-    }))
+    getIdTokenResult.mockResolvedValue(mockFirebaseUserWithClaims)
 
     const { result } = renderHook(() => useFirebaseUser())
 
@@ -523,18 +487,15 @@ describe('useFirebaseUser', () => {
 
     // Intercept the getIdToken call
     const idTokenResult = createMockIdTokenResult()
-    const getIdTokenResult = jest.fn(async () => idTokenResult)
+    getIdTokenResult.mockResolvedValue(idTokenResult)
 
     let onIdTokenChangedCallback
+
     // Capture the onIdTokenChanged callback
-    const onIdTokenChanged = jest.fn((callback) => {
+    onIdTokenChanged.mockImplementation((_, callback) => {
       onIdTokenChangedCallback = callback
       return () => {} // "unsubscribe" function
     })
-    jest.spyOn(firebase, 'auth').mockImplementation(() => ({
-      currentUser: { getIdTokenResult },
-      onIdTokenChanged,
-    }))
 
     const { result } = renderHook(() => useFirebaseUser())
 
@@ -572,18 +533,13 @@ describe('useFirebaseUser', () => {
     let onIdTokenChangedCallback
 
     // Capture the onIdTokenChanged callback
-    const onIdTokenChanged = jest.fn((callback) => {
+    onIdTokenChanged.mockImplementation((_, callback) => {
       onIdTokenChangedCallback = callback
       return () => {} // "unsubscribe" function
     })
 
     // Intercept the getIdToken call
-    const getIdTokenResult = jest.fn(async () => mockFirebaseUserWithClaims)
-
-    jest.spyOn(firebase, 'auth').mockImplementation(() => ({
-      currentUser: { getIdTokenResult },
-      onIdTokenChanged,
-    }))
+    getIdTokenResult.mockResolvedValue(mockFirebaseUserWithClaims)
 
     const { result } = renderHook(() => useFirebaseUser())
 
@@ -645,16 +601,14 @@ describe('useFirebaseUser', () => {
     })
     const mockFirebaseUser = createMockFirebaseUserClientSDK()
     const idTokenResult = createMockIdTokenResult()
-    const getIdTokenResult = jest.fn(async () => idTokenResult)
+    getIdTokenResult.mockResolvedValue(idTokenResult)
+
     let onIdTokenChangedCallback
-    const onIdTokenChanged = jest.fn((callback) => {
+    // Capture the onIdTokenChanged callback
+    onIdTokenChanged.mockImplementation((_, callback) => {
       onIdTokenChangedCallback = callback
-      return () => {}
+      return () => {} // "unsubscribe" function
     })
-    jest.spyOn(firebase, 'auth').mockImplementation(() => ({
-      currentUser: { getIdTokenResult },
-      onIdTokenChanged,
-    }))
 
     renderHook(() => useFirebaseUser())
 

--- a/src/initFirebaseClientSDK.js
+++ b/src/initFirebaseClientSDK.js
@@ -1,19 +1,19 @@
-import firebase from 'firebase/app'
-import 'firebase/auth'
+import { getApp, getApps, initializeApp } from 'firebase/app'
+import { getAuth, connectAuthEmulator } from 'firebase/auth'
 import { getConfig } from 'src/config'
 
 export default function initFirebaseClientSDK() {
   const { firebaseClientInitConfig, firebaseAuthEmulatorHost } = getConfig()
-  if (!firebase.apps.length) {
+  if (!getApps().length) {
     if (!firebaseClientInitConfig) {
       throw new Error(
         'If not initializing the Firebase JS SDK elsewhere, you must provide "firebaseClientInitConfig" to next-firebase-auth.'
       )
     }
-    firebase.initializeApp(firebaseClientInitConfig)
+    initializeApp(firebaseClientInitConfig)
   }
   // If the user has provided the firebaseAuthEmulatorHost address, set the emulator
   if (firebaseAuthEmulatorHost) {
-    firebase.auth().useEmulator(`http://${firebaseAuthEmulatorHost}`)
+    connectAuthEmulator(getAuth(getApp()), `http://${firebaseAuthEmulatorHost}`)
   }
 }

--- a/src/useFirebaseUser.js
+++ b/src/useFirebaseUser.js
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
-import firebase from 'firebase/app'
-import 'firebase/auth'
+import { getApp } from 'firebase/app'
+import { getAuth, getIdTokenResult, onIdTokenChanged } from 'firebase/auth'
 import { getConfig } from 'src/config'
 import createAuthUser from 'src/createAuthUser'
 import { filterStandardClaims } from 'src/claims'
@@ -80,9 +80,7 @@ const useFirebaseUser = () => {
       if (firebaseUser) {
         // Get the user's claims:
         // https://firebase.google.com/docs/reference/js/firebase.auth.IDTokenResult
-        const idTokenResult = await firebase
-          .auth()
-          .currentUser.getIdTokenResult()
+        const idTokenResult = await getIdTokenResult(firebaseUser)
         customClaims = filterStandardClaims(idTokenResult.claims)
       }
 
@@ -113,7 +111,7 @@ const useFirebaseUser = () => {
     }
 
     // https://firebase.google.com/docs/reference/js/firebase.auth.Auth#onidtokenchanged
-    const unsubscribe = firebase.auth().onIdTokenChanged(onIdTokenChange)
+    const unsubscribe = onIdTokenChanged(getAuth(getApp()), onIdTokenChange)
     return () => {
       unsubscribe()
       isCancelled = true

--- a/yarn.lock
+++ b/yarn.lock
@@ -1277,21 +1277,42 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@firebase/analytics-types@0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@firebase/analytics-types/-/analytics-types-0.5.0.tgz#cfa1dc34034fc478eca360f5faa4b4d0466892ce"
-  integrity sha512-VTV5Xtq5gVabbL/4n6pBtMJWcQBgOUDE2XbEHl8EOuwRaU9weyGUS7ofbisDkpl1RlFU1aewnc33pbLcYbi0iQ==
-
-"@firebase/analytics@0.6.16":
-  version "0.6.16"
-  resolved "https://registry.yarnpkg.com/@firebase/analytics/-/analytics-0.6.16.tgz#27bb3220ae70f83bb5c2ebde1e78087abfbf17f5"
-  integrity sha512-eBYWKf7S7xmDFi3cWLs7Z6x4Hn1AG1oy2Xp/RvfyamhqI2X8GbgyCif/+q7orh+MWnNwipblVT93YajhhXpQcQ==
+"@firebase/analytics-compat@0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@firebase/analytics-compat/-/analytics-compat-0.1.0.tgz#48f0c3b5557541dd0f1a463ffd1d807454ae1b8e"
+  integrity sha512-oaf1FEF7cKci5tO7f52dH63/ZwkBqbdSLLpgo6kyoYoYDuY+on4yAc1CIHh3sNj/L8T4Ni81IQvVs9lE/9oOpg==
   dependencies:
-    "@firebase/analytics-types" "0.5.0"
-    "@firebase/component" "0.5.5"
-    "@firebase/installations" "0.4.31"
+    "@firebase/analytics" "0.7.0"
+    "@firebase/analytics-types" "0.7.0"
+    "@firebase/component" "0.5.6"
+    "@firebase/util" "1.3.0"
+    tslib "^2.1.0"
+
+"@firebase/analytics-types@0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@firebase/analytics-types/-/analytics-types-0.7.0.tgz#91960e7c87ce8bf18cf8dd9e55ccbf5dc3989b5d"
+  integrity sha512-DNE2Waiwy5+zZnCfintkDtBfaW6MjIG883474v6Z0K1XZIvl76cLND4iv0YUb48leyF+PJK1KO2XrgHb/KpmhQ==
+
+"@firebase/analytics@0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@firebase/analytics/-/analytics-0.7.0.tgz#7f4450936a2cac3227cc6439130c09b9a0a7d83e"
+  integrity sha512-YEPyeW6CV8xbIvWaJMvfRdWUPKe/xchJ1bjV6GpLfkYRX+ZE1/YSNU14pX292M4bZ6Qg+bbu2DuWp8fEpa/YQg==
+  dependencies:
+    "@firebase/component" "0.5.6"
+    "@firebase/installations" "0.5.0"
     "@firebase/logger" "0.2.6"
-    "@firebase/util" "1.2.0"
+    "@firebase/util" "1.3.0"
+    tslib "^2.1.0"
+
+"@firebase/app-check-compat@0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@firebase/app-check-compat/-/app-check-compat-0.1.0.tgz#5bf12e5cd82f76cac2eabe51345d1fed9664ed48"
+  integrity sha512-T1M2d1oroaHUa448fgx3BdfWg4WXP64yybIWxvmVBuh7YnyMuegJK1sS9zipKBKLkstcQK8vivXYh3+/AnbGFw==
+  dependencies:
+    "@firebase/app-check" "0.4.0"
+    "@firebase/component" "0.5.6"
+    "@firebase/logger" "0.2.6"
+    "@firebase/util" "1.3.0"
     tslib "^2.1.0"
 
 "@firebase/app-check-interop-types@0.1.0":
@@ -1299,21 +1320,25 @@
   resolved "https://registry.yarnpkg.com/@firebase/app-check-interop-types/-/app-check-interop-types-0.1.0.tgz#83afd9d41f99166c2bdb2d824e5032e9edd8fe53"
   integrity sha512-uZfn9s4uuRsaX5Lwx+gFP3B6YsyOKUE+Rqa6z9ojT4VSRAsZFko9FRn6OxQUA1z5t5d08fY4pf+/+Dkd5wbdbA==
 
-"@firebase/app-check-types@0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@firebase/app-check-types/-/app-check-types-0.2.0.tgz#b938e03914b8139796a8923bb20a9004114d5409"
-  integrity sha512-CfZhWtChLK9uNmrxbJyTg1BPtROiwc/VJGu3f39KjS0F5ZvZjHmyRFMrDiSoXDoybM4B6X0pQhJYi9rifT2wpQ==
-
-"@firebase/app-check@0.2.1":
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/@firebase/app-check/-/app-check-0.2.1.tgz#3dd87dfa1832ee9a662489cce28261eaff23ef5d"
-  integrity sha512-Qswn+qHiAyi3P0O/W9BffDFX4MmptSod49zhWQt8vV42JyKSZexaXQpeNlfKgdE5jX8wUw8Vkk8My4PfIrPkww==
+"@firebase/app-check@0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@firebase/app-check/-/app-check-0.4.0.tgz#a048fc396b2a97ef8eba77fe909efbff07a5c75c"
+  integrity sha512-KQ/k8cukzZbH/LC9Iu5/Dbhr7w6byu8bYjfCA38B6v8aISgASYfP/nirxRD+hSuDoxXtAnPGEuv+v0YU3D1R2w==
   dependencies:
-    "@firebase/app-check-interop-types" "0.1.0"
-    "@firebase/app-check-types" "0.2.0"
-    "@firebase/component" "0.5.5"
+    "@firebase/component" "0.5.6"
     "@firebase/logger" "0.2.6"
-    "@firebase/util" "1.2.0"
+    "@firebase/util" "1.3.0"
+    tslib "^2.1.0"
+
+"@firebase/app-compat@0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@firebase/app-compat/-/app-compat-0.1.0.tgz#101070141198304a50ec546b7626870c7759166b"
+  integrity sha512-jnAeFM1ihY5klqg2dvdA4EOk7co8ffSHUj/efqaSwTrMkKTcG/WZKF9WAuXdl+5jEu1BhsGGHveWzGliTFH5Hg==
+  dependencies:
+    "@firebase/app" "0.7.0"
+    "@firebase/component" "0.5.6"
+    "@firebase/logger" "0.2.6"
+    "@firebase/util" "1.3.0"
     tslib "^2.1.0"
 
 "@firebase/app-types@0.6.3":
@@ -1321,35 +1346,55 @@
   resolved "https://registry.yarnpkg.com/@firebase/app-types/-/app-types-0.6.3.tgz#3f10514786aad846d74cd63cb693556309918f4b"
   integrity sha512-/M13DPPati7FQHEQ9Minjk1HGLm/4K4gs9bR4rzLCWJg64yGtVC0zNg9gDpkw9yc2cvol/mNFxqTtd4geGrwdw==
 
-"@firebase/app@0.6.29":
-  version "0.6.29"
-  resolved "https://registry.yarnpkg.com/@firebase/app/-/app-0.6.29.tgz#e2f88274b39917ab766f9fe73da48c353eaed557"
-  integrity sha512-duCzk9/BSVVsb5Y9b0rnvGSuD5zQA/JghiQsccRl+lA4xiUYjFudTU4cVFftkw+0zzeYBHn4KiVxchsva1O9dA==
+"@firebase/app-types@0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@firebase/app-types/-/app-types-0.7.0.tgz#c9e16d1b8bed1a991840b8d2a725fb58d0b5899f"
+  integrity sha512-6fbHQwDv2jp/v6bXhBw2eSRbNBpxHcd1NBF864UksSMVIqIyri9qpJB1Mn6sGZE+bnDsSQBC5j2TbMxYsJQkQg==
+
+"@firebase/app@0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@firebase/app/-/app-0.7.0.tgz#989e9f354951de2a8ac806f6e3fa0afd9f80b470"
+  integrity sha512-l4Pd69re6JyjumQrl719dnY5JSKROSYda/0N2wzOhSzqg8DsZOIErr8+xj6QAE6BtNsoIEk7ma9WMS/2r02MhA==
   dependencies:
-    "@firebase/app-types" "0.6.3"
-    "@firebase/component" "0.5.5"
+    "@firebase/component" "0.5.6"
     "@firebase/logger" "0.2.6"
-    "@firebase/util" "1.2.0"
-    dom-storage "2.1.0"
+    "@firebase/util" "1.3.0"
     tslib "^2.1.0"
-    xmlhttprequest "1.8.0"
+
+"@firebase/auth-compat@0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@firebase/auth-compat/-/auth-compat-0.1.0.tgz#e5dc6bb6ac89ea21f85c4153eb1cf8a7d69deaa8"
+  integrity sha512-OfAt3c5ham07xvmYyJp02v8mUa+HaSEwilvgD2M1JaWqLAtqH66bdBhLBE9N0pq8xtRdXZIF1vSd20a0ulQfQg==
+  dependencies:
+    "@firebase/auth" "0.17.0"
+    "@firebase/auth-types" "0.11.0"
+    "@firebase/component" "0.5.6"
+    "@firebase/util" "1.3.0"
+    node-fetch "2.6.1"
+    selenium-webdriver "^4.0.0-beta.2"
+    tslib "^2.1.0"
 
 "@firebase/auth-interop-types@0.1.6":
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/@firebase/auth-interop-types/-/auth-interop-types-0.1.6.tgz#5ce13fc1c527ad36f1bb1322c4492680a6cf4964"
   integrity sha512-etIi92fW3CctsmR9e3sYM3Uqnoq861M0Id9mdOPF6PWIg38BXL5k4upCNBggGUpLIS0H1grMOvy/wn1xymwe2g==
 
-"@firebase/auth-types@0.10.3":
-  version "0.10.3"
-  resolved "https://registry.yarnpkg.com/@firebase/auth-types/-/auth-types-0.10.3.tgz#2be7dd93959c8f5304c63e09e98718e103464d8c"
-  integrity sha512-zExrThRqyqGUbXOFrH/sowuh2rRtfKHp9SBVY2vOqKWdCX1Ztn682n9WLtlUDsiYVIbBcwautYWk2HyCGFv0OA==
+"@firebase/auth-types@0.11.0":
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/@firebase/auth-types/-/auth-types-0.11.0.tgz#b9c73c60ca07945b3bbd7a097633e5f78fa9e886"
+  integrity sha512-q7Bt6cx+ySj9elQHTsKulwk3+qDezhzRBFC9zlQ1BjgMueUOnGMcvqmU0zuKlQ4RhLSH7MNAdBV2znVaoN3Vxw==
 
-"@firebase/auth@0.16.8":
-  version "0.16.8"
-  resolved "https://registry.yarnpkg.com/@firebase/auth/-/auth-0.16.8.tgz#4edd44673d3711e94cfa1e6b03883214ae1f2255"
-  integrity sha512-mR0UXG4LirWIfOiCWxVmvz1o23BuKGxeItQ2cCUgXLTjNtWJXdcky/356iTUsd7ZV5A78s2NHeN5tIDDG6H4rg==
+"@firebase/auth@0.17.0":
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/@firebase/auth/-/auth-0.17.0.tgz#e1395779293e1869fabefd07e078242c773b5fcb"
+  integrity sha512-4zOGTLGzMjBX96KEyBNYpjOD87c2efCZvUjaJ53QslleW9Xp8kSsSHLRhr8hOkcRXO17CmBKSRx/LnG2vTZWQQ==
   dependencies:
-    "@firebase/auth-types" "0.10.3"
+    "@firebase/component" "0.5.6"
+    "@firebase/logger" "0.2.6"
+    "@firebase/util" "1.3.0"
+    node-fetch "2.6.1"
+    selenium-webdriver "4.0.0-beta.1"
+    tslib "^2.1.0"
 
 "@firebase/component@0.5.5":
   version "0.5.5"
@@ -1359,6 +1404,26 @@
     "@firebase/util" "1.2.0"
     tslib "^2.1.0"
 
+"@firebase/component@0.5.6":
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/@firebase/component/-/component-0.5.6.tgz#6b7c7aff69866e0925721543a2ef5f47b0f97cbe"
+  integrity sha512-GyQJ+2lrhsDqeGgd1VdS7W+Y6gNYyI0B51ovNTxeZVG/W8I7t9MwEiCWsCvfm5wQgfsKp9dkzOcJrL5k8oVO/Q==
+  dependencies:
+    "@firebase/util" "1.3.0"
+    tslib "^2.1.0"
+
+"@firebase/database-compat@0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@firebase/database-compat/-/database-compat-0.1.0.tgz#f02abaa9f493fd14aaae6e2b34262bafc5d033c7"
+  integrity sha512-jLN0JMYnYijg8f3QFtSuPGNuKAt3yYVRsHHlR8sADgx8MptByRRwVmMOk7QPc/DY7qscZIJow3hXFwvbeApFLA==
+  dependencies:
+    "@firebase/component" "0.5.6"
+    "@firebase/database" "0.12.0"
+    "@firebase/database-types" "0.9.0"
+    "@firebase/logger" "0.2.6"
+    "@firebase/util" "1.3.0"
+    tslib "^2.1.0"
+
 "@firebase/database-types@0.7.3", "@firebase/database-types@^0.7.2":
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/@firebase/database-types/-/database-types-0.7.3.tgz#819f16dd4c767c864b460004458620f265a3f735"
@@ -1366,7 +1431,27 @@
   dependencies:
     "@firebase/app-types" "0.6.3"
 
-"@firebase/database@0.10.9", "@firebase/database@^0.10.0":
+"@firebase/database-types@0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@firebase/database-types/-/database-types-0.9.0.tgz#dad3db745531f40b60f7726a76b2bf6bbf6c6471"
+  integrity sha512-x2TeTVnMZGPvT3y4Nayio4WprQA/zGwqMrPMQwSdF+PFnaFJAhA/eLgUB6cmWFzFYO9VvmuRkFzDzo6ezTo1Zw==
+  dependencies:
+    "@firebase/app-types" "0.7.0"
+    "@firebase/util" "1.3.0"
+
+"@firebase/database@0.12.0":
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/@firebase/database/-/database-0.12.0.tgz#2aa33138128cfcaf74388efe13e0eda10825d564"
+  integrity sha512-/gl6z6fAxAAFAdDllzidzweGpuXJu0b9AusSLrdW4LpP6KCuxJbhonMJuSGpHLzAHzx6Q9uitbvqHqBb17sttQ==
+  dependencies:
+    "@firebase/auth-interop-types" "0.1.6"
+    "@firebase/component" "0.5.6"
+    "@firebase/logger" "0.2.6"
+    "@firebase/util" "1.3.0"
+    faye-websocket "0.11.3"
+    tslib "^2.1.0"
+
+"@firebase/database@^0.10.0":
   version "0.10.9"
   resolved "https://registry.yarnpkg.com/@firebase/database/-/database-0.10.9.tgz#79f7b03cbe8a127dddfb7ea7748a3e923990f046"
   integrity sha512-Jxi9SiE4cNOftO9YKlG71ccyWFw4kSM9AG/xYu6vWXUGBr39Uw1TvYougANOcU21Q0TP4J08VPGnOnpXk/FGbQ==
@@ -1379,55 +1464,72 @@
     faye-websocket "0.11.3"
     tslib "^2.1.0"
 
-"@firebase/firestore-types@2.3.0":
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/@firebase/firestore-types/-/firestore-types-2.3.0.tgz#baf5c9470ba8be96bf0d76b83b413f03104cf565"
-  integrity sha512-QTW7NP7nDL0pgT/X53lyj+mIMh4nRQBBTBlRNQBt7eSyeqBf3ag3bxdQhCg358+5KbjYTC2/O6QtX9DlJZmh1A==
-
-"@firebase/firestore@2.3.10":
-  version "2.3.10"
-  resolved "https://registry.yarnpkg.com/@firebase/firestore/-/firestore-2.3.10.tgz#76d5137e5c37d33ccf3c5d77a9261c73493494b2"
-  integrity sha512-O+XpaZVhDIBK2fMwBUBR2BuhaXF6zTmz+afAuXAx18DK+2rFfLefbALZLaUYw0Aabe9pryy0c7OenzRbHA8n4Q==
+"@firebase/firestore-compat@0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@firebase/firestore-compat/-/firestore-compat-0.1.0.tgz#9faa1c10a76d67f812dd48469693e8f6bafca3ab"
+  integrity sha512-25r1jGpnnx7vXSPVLmHNkuz+EGpZDU5Luro5/MFCMmoV4a+Rmg2n9FRlxRyPn4XOCkc5nrBpT6ESAKAPSNHcpw==
   dependencies:
-    "@firebase/component" "0.5.5"
-    "@firebase/firestore-types" "2.3.0"
+    "@firebase/component" "0.5.6"
+    "@firebase/firestore" "3.0.0"
+    "@firebase/firestore-types" "2.5.0"
+    "@firebase/util" "1.3.0"
+    tslib "^2.1.0"
+
+"@firebase/firestore-types@2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@firebase/firestore-types/-/firestore-types-2.5.0.tgz#16fca40b6980fdb000de86042d7a96635f2bcdd7"
+  integrity sha512-I6c2m1zUhZ5SH0cWPmINabDyH5w0PPFHk2UHsjBpKdZllzJZ2TwTkXbDtpHUZNmnc/zAa0WNMNMvcvbb/xJLKA==
+
+"@firebase/firestore@3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@firebase/firestore/-/firestore-3.0.0.tgz#f7b8cc3d8d28b85a901fd66df13f4d61dcc33190"
+  integrity sha512-rbs5EbU/01f7NKHDtedBowpBlqnkVnQlpIuSX5wwGMiPgH8f9pMhh59JMk0cTaSqsJXsq3KvafWAD9SqWIqe2w==
+  dependencies:
+    "@firebase/component" "0.5.6"
     "@firebase/logger" "0.2.6"
-    "@firebase/util" "1.2.0"
+    "@firebase/util" "1.3.0"
     "@firebase/webchannel-wrapper" "0.5.1"
     "@grpc/grpc-js" "^1.3.2"
     "@grpc/proto-loader" "^0.6.0"
     node-fetch "2.6.1"
     tslib "^2.1.0"
 
-"@firebase/functions-types@0.4.0":
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/@firebase/functions-types/-/functions-types-0.4.0.tgz#0b789f4fe9a9c0b987606c4da10139345b40f6b9"
-  integrity sha512-3KElyO3887HNxtxNF1ytGFrNmqD+hheqjwmT3sI09FaDCuaxGbOnsXAXH2eQ049XRXw9YQpHMgYws/aUNgXVyQ==
-
-"@firebase/functions@0.6.14":
-  version "0.6.14"
-  resolved "https://registry.yarnpkg.com/@firebase/functions/-/functions-0.6.14.tgz#f6b452a53dc15299595bd079dd6ed4afb59e1a8c"
-  integrity sha512-Gthru/wHPQqkn651MenVM+qKVFFqIyFcNT3qfJUacibqrKlvDtYtaCMjFGAkChuGnYzNVnXJIaNrIHkEIII4Hg==
+"@firebase/functions-compat@0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@firebase/functions-compat/-/functions-compat-0.1.0.tgz#53e2b3b9590b04628e9537806196d91deb3e6f3f"
+  integrity sha512-uNwHdGYqgIXzF7aTZBeUe00K/sadRg5EeSDuJ6VNo3Gh3ZceX4eRnL5p7l2bEJBh8hBl0brb82+TRYjGHtjtFQ==
   dependencies:
-    "@firebase/component" "0.5.5"
-    "@firebase/functions-types" "0.4.0"
-    "@firebase/messaging-types" "0.5.0"
+    "@firebase/component" "0.5.6"
+    "@firebase/functions" "0.7.0"
+    "@firebase/functions-types" "0.5.0"
+    "@firebase/util" "1.3.0"
+    tslib "^2.1.0"
+
+"@firebase/functions-types@0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@firebase/functions-types/-/functions-types-0.5.0.tgz#b50ba95ccce9e96f7cda453228ffe1684645625b"
+  integrity sha512-qza0M5EwX+Ocrl1cYI14zoipUX4gI/Shwqv0C1nB864INAD42Dgv4v94BCyxGHBg2kzlWy8PNafdP7zPO8aJQA==
+
+"@firebase/functions@0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@firebase/functions/-/functions-0.7.0.tgz#d052d01aa6871f5cd518748963792bae94b2081d"
+  integrity sha512-H0krTllYh5eK7utKoUoNoVvoSdZqaPdqGSdIK7ltr1yWX9UhbRWYZv5B/tWTjQFfDfRQwpn9Q6svoJzYZQiusA==
+  dependencies:
+    "@firebase/app-check-interop-types" "0.1.0"
+    "@firebase/auth-interop-types" "0.1.6"
+    "@firebase/component" "0.5.6"
+    "@firebase/messaging-interop-types" "0.1.0"
+    "@firebase/util" "1.3.0"
     node-fetch "2.6.1"
     tslib "^2.1.0"
 
-"@firebase/installations-types@0.3.4":
-  version "0.3.4"
-  resolved "https://registry.yarnpkg.com/@firebase/installations-types/-/installations-types-0.3.4.tgz#589a941d713f4f64bf9f4feb7f463505bab1afa2"
-  integrity sha512-RfePJFovmdIXb6rYwtngyxuEcWnOrzdZd9m7xAW0gRxDIjBT20n3BOhjpmgRWXo/DAxRmS7bRjWAyTHY9cqN7Q==
-
-"@firebase/installations@0.4.31":
-  version "0.4.31"
-  resolved "https://registry.yarnpkg.com/@firebase/installations/-/installations-0.4.31.tgz#dbde30c0542fb4343b075f0574d4e0d0f4b49aa7"
-  integrity sha512-qWolhAgMHvD3avsNCl+K8+untzoDDFQIRR8At8kyWMKKosy0vttdWTWzjvDoZbyKU6r0RNlxDUWAgV88Q8EudQ==
+"@firebase/installations@0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@firebase/installations/-/installations-0.5.0.tgz#4a21e1c7467795802b031af413df2555b17cf1b1"
+  integrity sha512-wF1CKIx+SoiEbtNdutulxW4z80B5lGXW+8JdAtcKQwgKxF0VtlCaDFsd9AEB3aTtzIve5UkGak8hQOMvvOpydg==
   dependencies:
-    "@firebase/component" "0.5.5"
-    "@firebase/installations-types" "0.3.4"
-    "@firebase/util" "1.2.0"
+    "@firebase/component" "0.5.6"
+    "@firebase/util" "1.3.0"
     idb "3.0.2"
     tslib "^2.1.0"
 
@@ -1436,38 +1538,59 @@
   resolved "https://registry.yarnpkg.com/@firebase/logger/-/logger-0.2.6.tgz#3aa2ca4fe10327cabf7808bd3994e88db26d7989"
   integrity sha512-KIxcUvW/cRGWlzK9Vd2KB864HlUnCfdTH0taHE0sXW5Xl7+W68suaeau1oKNEqmc3l45azkd4NzXTCWZRZdXrw==
 
-"@firebase/messaging-types@0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@firebase/messaging-types/-/messaging-types-0.5.0.tgz#c5d0ef309ced1758fda93ef3ac70a786de2e73c4"
-  integrity sha512-QaaBswrU6umJYb/ZYvjR5JDSslCGOH6D9P136PhabFAHLTR4TWjsaACvbBXuvwrfCXu10DtcjMxqfhdNIB1Xfg==
-
-"@firebase/messaging@0.7.15":
-  version "0.7.15"
-  resolved "https://registry.yarnpkg.com/@firebase/messaging/-/messaging-0.7.15.tgz#d3b9a053331238480860c71385819babda2076f3"
-  integrity sha512-81t6iJtqMBJF5LHTjDhlHUpbPZOV6dKhW0TueAoON4omc0SaDXgf4nnk6JkvZRfdcuOaP8848Cv53tvZPFFAYQ==
+"@firebase/messaging-compat@0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@firebase/messaging-compat/-/messaging-compat-0.1.0.tgz#ab164540f6ba954c8d150b2e96dc6bf8c1536eb4"
+  integrity sha512-58qQmKwOiXhxZwrRwwjQDbjlRx1uMVVuV/DNbDzqilDJDdoYXMdK6RBTF9Bs51qy/Z1BI2Q9B1JX01QYlgZpxQ==
   dependencies:
-    "@firebase/component" "0.5.5"
-    "@firebase/installations" "0.4.31"
-    "@firebase/messaging-types" "0.5.0"
-    "@firebase/util" "1.2.0"
+    "@firebase/component" "0.5.6"
+    "@firebase/messaging" "0.9.0"
+    "@firebase/util" "1.3.0"
+    tslib "^2.1.0"
+
+"@firebase/messaging-interop-types@0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@firebase/messaging-interop-types/-/messaging-interop-types-0.1.0.tgz#bdac02dd31edd5cb9eec37b1db698ea5e2c1a631"
+  integrity sha512-DbvUl/rXAZpQeKBnwz0NYY5OCqr2nFA0Bj28Fmr3NXGqR4PAkfTOHuQlVtLO1Nudo3q0HxAYLa68ZDAcuv2uKQ==
+
+"@firebase/messaging@0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@firebase/messaging/-/messaging-0.9.0.tgz#a868bea75d0c26210903178cf22d31c47bc84584"
+  integrity sha512-NTUB+gVJsgL/f6wqwUlgadaNuLZvyk1IlTcRvR3391t8jDSWOT2efwzNqcI7Xv4nhzaiPhzAQ4ncH/m8kfUUXQ==
+  dependencies:
+    "@firebase/component" "0.5.6"
+    "@firebase/installations" "0.5.0"
+    "@firebase/messaging-interop-types" "0.1.0"
+    "@firebase/util" "1.3.0"
     idb "3.0.2"
     tslib "^2.1.0"
 
-"@firebase/performance-types@0.0.13":
-  version "0.0.13"
-  resolved "https://registry.yarnpkg.com/@firebase/performance-types/-/performance-types-0.0.13.tgz#58ce5453f57e34b18186f74ef11550dfc558ede6"
-  integrity sha512-6fZfIGjQpwo9S5OzMpPyqgYAUZcFzZxHFqOyNtorDIgNXq33nlldTL/vtaUZA8iT9TT5cJlCrF/jthKU7X21EA==
-
-"@firebase/performance@0.4.17":
-  version "0.4.17"
-  resolved "https://registry.yarnpkg.com/@firebase/performance/-/performance-0.4.17.tgz#b160a4352f682c1039b49ec9d24d6c473a31b3c3"
-  integrity sha512-uhDs9rhdMrGraYHcd3CTRkGtcNap4hp6rAHTwJNIX56Z3RzQ1VW2ea9vvesl7EjFtEIPU0jfdrS32wV+qer5DQ==
+"@firebase/performance-compat@0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@firebase/performance-compat/-/performance-compat-0.1.0.tgz#c1edeccd9b60d83de26d8e645e0d2ddd64e9a2d7"
+  integrity sha512-H+/A5+y/15hFn5FHRP8lcogDzO6qm9YoACNEXn71UN4PiGQ+/BbHkQafDEXxD6wLfqfqR8u8oclHPFIYxMBF7Q==
   dependencies:
-    "@firebase/component" "0.5.5"
-    "@firebase/installations" "0.4.31"
+    "@firebase/component" "0.5.6"
     "@firebase/logger" "0.2.6"
-    "@firebase/performance-types" "0.0.13"
-    "@firebase/util" "1.2.0"
+    "@firebase/performance" "0.5.0"
+    "@firebase/performance-types" "0.1.0"
+    "@firebase/util" "1.3.0"
+    tslib "^2.1.0"
+
+"@firebase/performance-types@0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@firebase/performance-types/-/performance-types-0.1.0.tgz#5e6efa9dc81860aee2cb7121b39ae8fa137e69fc"
+  integrity sha512-6p1HxrH0mpx+622Ql6fcxFxfkYSBpE3LSuwM7iTtYU2nw91Hj6THC8Bc8z4nboIq7WvgsT/kOTYVVZzCSlXl8w==
+
+"@firebase/performance@0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@firebase/performance/-/performance-0.5.0.tgz#cc237e65791c75dba856ace8971b94d7adcbc60b"
+  integrity sha512-E+L18eJKshr/ijnWZMexEEddwkp2T4Ye2dJSK4TcOKRYfrmfZJ95RRZ+MPNp1ES7RH2JYiyym1NIQKPcNNvhug==
+  dependencies:
+    "@firebase/component" "0.5.6"
+    "@firebase/installations" "0.5.0"
+    "@firebase/logger" "0.2.6"
+    "@firebase/util" "1.3.0"
     tslib "^2.1.0"
 
 "@firebase/polyfill@0.3.36":
@@ -1479,36 +1602,57 @@
     promise-polyfill "8.1.3"
     whatwg-fetch "2.0.4"
 
-"@firebase/remote-config-types@0.1.9":
-  version "0.1.9"
-  resolved "https://registry.yarnpkg.com/@firebase/remote-config-types/-/remote-config-types-0.1.9.tgz#fe6bbe4d08f3b6e92fce30e4b7a9f4d6a96d6965"
-  integrity sha512-G96qnF3RYGbZsTRut7NBX0sxyczxt1uyCgXQuH/eAfUCngxjEGcZQnBdy6mvSdqdJh5mC31rWPO4v9/s7HwtzA==
-
-"@firebase/remote-config@0.1.42":
-  version "0.1.42"
-  resolved "https://registry.yarnpkg.com/@firebase/remote-config/-/remote-config-0.1.42.tgz#84573ac2f1ee49cb9d4327a25c5625f2e274695d"
-  integrity sha512-hWwtAZmYLB274bxjV2cdMYhyBCUUqbYErihGx3rMyab76D+VbIxOuKJb2z0DS67jQG+SA3pr9/MtWsTPHV/l9g==
+"@firebase/remote-config-compat@0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@firebase/remote-config-compat/-/remote-config-compat-0.1.0.tgz#8eb2582d1909dd4d5023383e43d73ad605d56daa"
+  integrity sha512-PpCh5f5hUUaDCmiJsuu/u9a0g0G5WH3YSbfH1jPejVOaJ1lS82615E7WOzco4zMllLYfX62VaUYD2vvcLyXE/w==
   dependencies:
-    "@firebase/component" "0.5.5"
-    "@firebase/installations" "0.4.31"
+    "@firebase/component" "0.5.6"
     "@firebase/logger" "0.2.6"
-    "@firebase/remote-config-types" "0.1.9"
-    "@firebase/util" "1.2.0"
+    "@firebase/remote-config" "0.2.0"
+    "@firebase/remote-config-types" "0.2.0"
+    "@firebase/util" "1.3.0"
     tslib "^2.1.0"
 
-"@firebase/storage-types@0.4.1":
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/@firebase/storage-types/-/storage-types-0.4.1.tgz#da6582ae217e3db485c90075dc71100ca5064cc6"
-  integrity sha512-IM4cRzAnQ6QZoaxVZ5MatBzqXVcp47hOlE28jd9xXw1M9V7gfjhmW0PALGFQx58tPVmuUwIKyoEbHZjV4qRJwQ==
+"@firebase/remote-config-types@0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@firebase/remote-config-types/-/remote-config-types-0.2.0.tgz#1e2759fc01f20b58c564db42196f075844c3d1fd"
+  integrity sha512-hqK5sCPeZvcHQ1D6VjJZdW6EexLTXNMJfPdTwbD8NrXUw6UjWC4KWhLK/TSlL0QPsQtcKRkaaoP+9QCgKfMFPw==
 
-"@firebase/storage@0.6.1":
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/@firebase/storage/-/storage-0.6.1.tgz#29d1568e78c9234af72a609409a36403346a60b8"
-  integrity sha512-00WEdmmKoKUHBsufUIUDgBS5ghAe8tCp1QbHQnnlf3aekAgFf8UKjfR6QMaHoEIzuZPhWPStQ5KrrIcWA/MMQg==
+"@firebase/remote-config@0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@firebase/remote-config/-/remote-config-0.2.0.tgz#aa2bd7b34e0e40a259c3f0409a5084864f234f0f"
+  integrity sha512-hNZ+BqsTmfe8ogpeow95NSwQmKIeetKdPxKpyC6RZBeFUae782+2HrUx4/Quep6OZjOHQF6xZ5d3VOxu2ZKEfg==
   dependencies:
-    "@firebase/component" "0.5.5"
-    "@firebase/storage-types" "0.4.1"
-    "@firebase/util" "1.2.0"
+    "@firebase/component" "0.5.6"
+    "@firebase/installations" "0.5.0"
+    "@firebase/logger" "0.2.6"
+    "@firebase/util" "1.3.0"
+    tslib "^2.1.0"
+
+"@firebase/storage-compat@0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@firebase/storage-compat/-/storage-compat-0.1.0.tgz#b8080e3250b19ad6d98a5ade65f1a03aab73f2b8"
+  integrity sha512-DJstR2vidnyNSRp14LQhd9QO0PxhMm/xsXrPQ2IEmQ7EWDT4rxGd+pkqXTG6IO+k9ZKMc0BnWIYwlMqkGEJoDg==
+  dependencies:
+    "@firebase/component" "0.5.6"
+    "@firebase/storage" "0.8.0"
+    "@firebase/storage-types" "0.6.0"
+    "@firebase/util" "1.3.0"
+    tslib "^2.1.0"
+
+"@firebase/storage-types@0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@firebase/storage-types/-/storage-types-0.6.0.tgz#0b1af64a2965af46fca138e5b70700e9b7e6312a"
+  integrity sha512-1LpWhcCb1ftpkP/akhzjzeFxgVefs6eMD2QeKiJJUGH1qOiows2w5o0sKCUSQrvrRQS1lz3SFGvNR1Ck/gqxeA==
+
+"@firebase/storage@0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@firebase/storage/-/storage-0.8.0.tgz#2766a18a8a9684082d745ab1a93a3c88061169b1"
+  integrity sha512-D0HH+y3DLH0+8eOt6h19RffFMpdzPNr7Yv7XpeeM3+VLE4TbQnDie/OAQWOuWLrYoW7MsPQnLkx+zDb3DxOXxw==
+  dependencies:
+    "@firebase/component" "0.5.6"
+    "@firebase/util" "1.3.0"
     node-fetch "2.6.1"
     tslib "^2.1.0"
 
@@ -1516,6 +1660,13 @@
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@firebase/util/-/util-1.2.0.tgz#4d4e419bf8c9bc1bc51308d1953dc2e4353c0770"
   integrity sha512-8W9TTGImXr9cu+oyjBJ7yjoEd/IVAv0pBZA4c1uIuKrpGZi2ee38m+8xlZOBRmsAaOU/tR9DXz1WF/oeM6Fb7Q==
+  dependencies:
+    tslib "^2.1.0"
+
+"@firebase/util@1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@firebase/util/-/util-1.3.0.tgz#e71113bdd5073e9736ceca665b54d9f6df232b20"
+  integrity sha512-SESvmYwuKOVCZ1ZxLbberbx+9cnbxpCa4CG2FUSQYqN6Ab8KyltegMDIsqMw5KyIBZ4n1phfHoOa22xo5NzAlQ==
   dependencies:
     tslib "^2.1.0"
 
@@ -3853,11 +4004,6 @@ dom-accessibility-api@^0.5.6:
   resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.6.tgz#3f5d43b52c7a3bd68b5fb63fa47b4e4c1fdf65a9"
   integrity sha512-DplGLZd8L1lN64jlT27N9TVSESFR5STaEJvX+thCby7fuCHonfPpAlodYc3vuUYbDuDec5w8AMP7oCM5TWFsqw==
 
-dom-storage@2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/dom-storage/-/dom-storage-2.1.0.tgz#00fb868bc9201357ea243c7bcfd3304c1e34ea39"
-  integrity sha512-g6RpyWXzl0RR6OTElHKBl7nwnK87GUyZMYC7JWsB/IA73vpqK2K6LT39x4VepLxlSsWBFrPVLnsSR5Jyty0+2Q==
-
 domain-browser@4.19.0:
   version "4.19.0"
   resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-4.19.0.tgz#1093e17c0a17dbd521182fe90d49ac1370054af1"
@@ -4564,10 +4710,10 @@ find-up@^4.0.0, find-up@^4.1.0:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
 
-firebase-admin@^9.11.0:
-  version "9.11.0"
-  resolved "https://registry.yarnpkg.com/firebase-admin/-/firebase-admin-9.11.0.tgz#c0c72e4480b836fb4cd15e6d834ddfbfb9cc54ba"
-  integrity sha512-68fXdwcKF99LkWBE33M5hnLwjvGpbCRznIOtZVsiBqZdM9iwxlTfNEpAckh++o3GdJcSLRUWmIN+MKqPUsxoCA==
+firebase-admin@^9.11.1:
+  version "9.11.1"
+  resolved "https://registry.yarnpkg.com/firebase-admin/-/firebase-admin-9.11.1.tgz#b4f472ed51951937f333a4d88a0693ad37ffc90a"
+  integrity sha512-Y9fjelljy6MKqwsSbM/UN1k8gBQh5zfm5fCTe0Z6Gch2T3nDUIPsTcf+jfe4o40/MPYuybili9XJjTMmM2e5MQ==
   dependencies:
     "@firebase/database" "^0.10.0"
     "@firebase/database-types" "^0.7.2"
@@ -4580,26 +4726,37 @@ firebase-admin@^9.11.0:
     "@google-cloud/firestore" "^4.5.0"
     "@google-cloud/storage" "^5.3.0"
 
-firebase@^8.8.1:
-  version "8.8.1"
-  resolved "https://registry.yarnpkg.com/firebase/-/firebase-8.8.1.tgz#b18dbb7283a9d50d3f3ef5b9deb9c1e15c9466b1"
-  integrity sha512-dzqQn3wwHhsStsD2gDs3XfSJ/SIqv5IA9Ht+MySnvrIsljk0V8bI/+EMPsh0h2VlYPSk51bmyNQZ4LvuSKNvlA==
+firebase@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/firebase/-/firebase-9.0.0.tgz#00bfa03a3eb99bde43a472a8861aa808068153bb"
+  integrity sha512-atgnuvELhU9D5w9moChnyCb6GRbOCqk54/kHN0J4kdLJBncpcb2culIJ7nlSHILMcW9MNMiNKDJ07RwXVyqFFA==
   dependencies:
-    "@firebase/analytics" "0.6.16"
-    "@firebase/app" "0.6.29"
-    "@firebase/app-check" "0.2.1"
-    "@firebase/app-types" "0.6.3"
-    "@firebase/auth" "0.16.8"
-    "@firebase/database" "0.10.9"
-    "@firebase/firestore" "2.3.10"
-    "@firebase/functions" "0.6.14"
-    "@firebase/installations" "0.4.31"
-    "@firebase/messaging" "0.7.15"
-    "@firebase/performance" "0.4.17"
+    "@firebase/analytics" "0.7.0"
+    "@firebase/analytics-compat" "0.1.0"
+    "@firebase/app" "0.7.0"
+    "@firebase/app-check" "0.4.0"
+    "@firebase/app-check-compat" "0.1.0"
+    "@firebase/app-compat" "0.1.0"
+    "@firebase/app-types" "0.7.0"
+    "@firebase/auth" "0.17.0"
+    "@firebase/auth-compat" "0.1.0"
+    "@firebase/database" "0.12.0"
+    "@firebase/database-compat" "0.1.0"
+    "@firebase/firestore" "3.0.0"
+    "@firebase/firestore-compat" "0.1.0"
+    "@firebase/functions" "0.7.0"
+    "@firebase/functions-compat" "0.1.0"
+    "@firebase/installations" "0.5.0"
+    "@firebase/messaging" "0.9.0"
+    "@firebase/messaging-compat" "0.1.0"
+    "@firebase/performance" "0.5.0"
+    "@firebase/performance-compat" "0.1.0"
     "@firebase/polyfill" "0.3.36"
-    "@firebase/remote-config" "0.1.42"
-    "@firebase/storage" "0.6.1"
-    "@firebase/util" "1.2.0"
+    "@firebase/remote-config" "0.2.0"
+    "@firebase/remote-config-compat" "0.1.0"
+    "@firebase/storage" "0.8.0"
+    "@firebase/storage-compat" "0.1.0"
+    "@firebase/util" "1.3.0"
 
 flat-cache@^3.0.4:
   version "3.0.4"
@@ -5069,6 +5226,11 @@ image-size@1.0.0:
   integrity sha512-JLJ6OwBfO1KcA+TvJT+v8gbE6iWbj24LyDNFgFEN0lzegn6cC6a/p3NIDaepMsJjQjlUWqIC7wJv8lBFxPNjcw==
   dependencies:
     queue "6.0.2"
+
+immediate@~3.0.5:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.0.6.tgz#9db1dbd0faf8de6fbe0f5dd5e56bb606280de69b"
+  integrity sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=
 
 import-fresh@^3.0.0, import-fresh@^3.2.1:
   version "3.3.0"
@@ -6053,6 +6215,16 @@ jsonwebtoken@^8.5.1:
     array-includes "^3.1.2"
     object.assign "^4.1.2"
 
+jszip@^3.5.0, jszip@^3.6.0:
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/jszip/-/jszip-3.7.1.tgz#bd63401221c15625a1228c556ca8a68da6fda3d9"
+  integrity sha512-ghL0tz1XG9ZEmRMcEN2vt7xabrDdqHHeykgARpmZ0BiIctWxM47Vt63ZO2dnp4QYt/xJVLLy5Zv1l/xRdh2byg==
+  dependencies:
+    lie "~3.3.0"
+    pako "~1.0.2"
+    readable-stream "~2.3.6"
+    set-immediate-shim "~1.0.1"
+
 jwa@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jwa/-/jwa-1.4.1.tgz#743c32985cb9e98655530d53641b66c8645b039a"
@@ -6166,6 +6338,13 @@ levn@~0.3.0:
   dependencies:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
+
+lie@~3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/lie/-/lie-3.3.0.tgz#dcf82dee545f46074daf200c7c1c5a08e0f40f6a"
+  integrity sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==
+  dependencies:
+    immediate "~3.0.5"
 
 limiter@^1.1.5:
   version "1.1.5"
@@ -6946,7 +7125,7 @@ p-try@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
-pako@~1.0.5:
+pako@~1.0.2, pako@~1.0.5:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
   integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
@@ -7399,7 +7578,7 @@ read-pkg@^3.0.0:
     normalize-package-data "^2.3.2"
     path-type "^3.0.0"
 
-readable-stream@^2.0.2, readable-stream@^2.3.3, readable-stream@^2.3.6:
+readable-stream@^2.0.2, readable-stream@^2.3.3, readable-stream@^2.3.6, readable-stream@~2.3.6:
   version "2.3.7"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
   integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
@@ -7608,6 +7787,13 @@ reusify@^1.0.4:
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
+rimraf@^2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
+  integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
+  dependencies:
+    glob "^7.1.3"
+
 rimraf@^3.0.0, rimraf@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
@@ -7694,6 +7880,26 @@ schema-utils@^3.1.0:
     ajv "^6.12.5"
     ajv-keywords "^3.5.2"
 
+selenium-webdriver@4.0.0-beta.1:
+  version "4.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/selenium-webdriver/-/selenium-webdriver-4.0.0-beta.1.tgz#db645b0d775f26e4e12235db05796a1bc1e7efda"
+  integrity sha512-DJ10z6Yk+ZBaLrt1CLElytQ/FOayx29ANKDtmtyW1A6kCJx3+dsc5fFMOZxwzukDniyYsC3OObT5pUAsgkjpxQ==
+  dependencies:
+    jszip "^3.5.0"
+    rimraf "^2.7.1"
+    tmp "^0.2.1"
+    ws "^7.3.1"
+
+selenium-webdriver@^4.0.0-beta.2:
+  version "4.0.0-beta.4"
+  resolved "https://registry.yarnpkg.com/selenium-webdriver/-/selenium-webdriver-4.0.0-beta.4.tgz#db4fc7505a515ea3b4a95ded031b738a1544eddd"
+  integrity sha512-+s/CIYkWzmnC9WASBxxVj7Lm0dcyl6OaFxwIJaFCT5WCuACiimEEr4lUnOOFP/QlKfkDQ56m+aRczaq2EvJEJg==
+  dependencies:
+    jszip "^3.6.0"
+    rimraf "^3.0.2"
+    tmp "^0.2.1"
+    ws ">=7.4.6"
+
 "semver@2 || 3 || 4 || 5", semver@^5.5.0, semver@^5.6.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
@@ -7727,6 +7933,11 @@ set-cookie-parser@^2.4.6:
   version "2.4.8"
   resolved "https://registry.yarnpkg.com/set-cookie-parser/-/set-cookie-parser-2.4.8.tgz#d0da0ed388bc8f24e706a391f9c9e252a13c58b2"
   integrity sha512-edRH8mBKEWNVIVMKejNnuJxleqYE/ZSdcT8/Nem9/mmosx12pctd80s2Oy00KNZzrogMZS5mauK2/ymL1bvlvg==
+
+set-immediate-shim@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz#4b2b1b27eb808a9f8dcc481a58e5e56f599f3f61"
+  integrity sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=
 
 set-value@^2.0.0, set-value@^2.0.1:
   version "2.0.1"
@@ -8309,6 +8520,13 @@ timers-browserify@2.0.12, timers-browserify@^2.0.4:
   integrity sha512-9phl76Cqm6FhSX9Xe1ZUAMLtm1BLkKj2Qd5ApyWkXzsMRaA7dgr81kf4wJmQf/hAvg8EEyJxDo3du/0KlhPiKQ==
   dependencies:
     setimmediate "^1.0.4"
+
+tmp@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.1.tgz#8457fc3037dcf4719c251367a1af6500ee1ccf14"
+  integrity sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==
+  dependencies:
+    rimraf "^3.0.0"
 
 tmpl@1.0.x:
   version "1.0.4"
@@ -8918,6 +9136,11 @@ write-file-atomic@^3.0.0:
     signal-exit "^3.0.2"
     typedarray-to-buffer "^3.1.5"
 
+ws@>=7.4.6:
+  version "8.2.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.2.1.tgz#bdd92b3c56fdb47d2379b5ae534281922cc5bd12"
+  integrity sha512-XkgWpJU3sHU7gX8f13NqTn6KQ85bd1WU7noBHTT8fSohx7OS1TPY8k+cyRPCzFkia7C4mM229yeHr1qK9sM4JQ==
+
 ws@^7.3.1:
   version "7.4.5"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.5.tgz#a484dd851e9beb6fdb420027e3885e8ce48986c1"
@@ -8942,11 +9165,6 @@ xmlchars@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
-
-xmlhttprequest@1.8.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz#67fe075c5c24fef39f9d65f5f7b7fe75171968fc"
-  integrity sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw=
 
 xtend@^4.0.0, xtend@^4.0.2:
   version "4.0.2"


### PR DESCRIPTION
This PR adds support for Firebase 9. It does not change the API of `next-firebase-auth`, so the refactor for users of the package will be relatively simple.

This PR also updates the mocks, tests, and examples accordingly. 