### PR TITLE
feat: add support for application default credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ const initAuth = () => {
       databaseURL: 'https://my-example-app.firebaseio.com',
     },
     // Use application default credentials (takes precedence over fireaseAdminInitConfig if set)
-    // firebaseAdminDefaultCredential: true,
+    // useFirebaseAdminDefaultCredential: true,
     firebaseClientInitConfig: {
       apiKey: 'MyExampleAppAPIKey123', // required
       authDomain: 'my-example-app.firebaseapp.com',
@@ -444,7 +444,7 @@ The `firebaseAdminInitConfig.credential.privateKey` cannot be defined on the cli
 >
 > See [this Vercel issue](https://github.com/vercel/vercel/issues/749#issuecomment-707515089) for more information.
 
-**firebaseAdminDefaultCredential**
+**useFirebaseAdminDefaultCredential**
 
 A boolean that when set to true, the application default credential will be passed to `firebase-admin`'s [`initializeApp`](https://firebase.google.com/docs/admin/setup#initialize-sdk). 
 

--- a/README.md
+++ b/README.md
@@ -80,13 +80,13 @@ const initAuth = () => {
       credential: {
         projectId: 'my-example-app-id',
         clientEmail: 'example-abc123@my-example-app.iam.gserviceaccount.com',
-        // The private key must not be accesssible on the client side.
+        // The private key must not be accessible on the client side.
         privateKey: process.env.FIREBASE_PRIVATE_KEY,
       },
       databaseURL: 'https://my-example-app.firebaseio.com',
     },
-    // Takes precedence over fireaseAdminInitConfig if set
-    // firebaseAdminDefaultCredential: true //
+    // Use application default credentials (takes precedence over fireaseAdminInitConfig if set)
+    // firebaseAdminDefaultCredential: true,
     firebaseClientInitConfig: {
       apiKey: 'MyExampleAppAPIKey123', // required
       authDomain: 'my-example-app.firebaseapp.com',
@@ -446,7 +446,7 @@ The `firebaseAdminInitConfig.credential.privateKey` cannot be defined on the cli
 
 **firebaseAdminDefaultCredential**
 
-When set to true, it passes application default credential to `firebase-admin`'s [`initializeApp`](https://firebase.google.com/docs/admin/setup#initialize-sdk). 
+A boolean that when set to true, the application default credential will be passed to `firebase-admin`'s [`initializeApp`](https://firebase.google.com/docs/admin/setup#initialize-sdk). 
 
 **NOTE**: When set to true default credentials will override values passed to `firebaseAdminInitConfig.credential`
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ const initAuth = () => {
       },
       databaseURL: 'https://my-example-app.firebaseio.com',
     },
+    // Takes precedence over fireaseAdminInitConfig if set
+    // firebaseAdminDefaultCredential: true //
     firebaseClientInitConfig: {
       apiKey: 'MyExampleAppAPIKey123', // required
       authDomain: 'my-example-app.firebaseapp.com',
@@ -428,7 +430,7 @@ Configuration passed to `firebase-admin`'s [`initializeApp`](https://firebase.go
 
 The `firebaseAdminInitConfig.credential.privateKey` cannot be defined on the client side and should live in a secret environment variable.
 
-> Note: if using environent variables in Vercel, add the private key *with double quotes* via the CLI:
+> Note: if using environment variables in Vercel, add the private key *with double quotes* via the CLI:
 >
 >   `vercel secrets add firebase-private-key '"my-key-here"'`
 >
@@ -441,6 +443,12 @@ The `firebaseAdminInitConfig.credential.privateKey` cannot be defined on the cli
 >    ```
 >
 > See [this Vercel issue](https://github.com/vercel/vercel/issues/749#issuecomment-707515089) for more information.
+
+**firebaseAdminDefaultCredential**
+
+When set to true, it passes application default credential to `firebase-admin`'s [`initializeApp`](https://firebase.google.com/docs/admin/setup#initialize-sdk). 
+
+**NOTE**: When set to true default credentials will override values passed to `firebaseAdminInitConfig.credential`
 
 **firebaseClientInitConfig**: Configuration passed to the Firebase JS SDK's [`initializeApp`](https://firebase.google.com/docs/reference/node/firebase#initializeapp). The "firebaseClientInitConfig.apiKey" value is always **required**. Other properties are required unless you initialize the `firebase` app yourself before initializing `next-firebase-auth`.
 

--- a/src/__tests__/initFirebaseAdminSDK.test.js
+++ b/src/__tests__/initFirebaseAdminSDK.test.js
@@ -39,13 +39,13 @@ describe('initFirebaseAdminSDK', () => {
     })
   })
 
-  it('calls admin.initializeApp with application default credentials if firebaseAdminDefaultCredential set to true', () => {
+  it('calls admin.initializeApp with application default credentials if useFirebaseAdminDefaultCredential set to true', () => {
     expect.assertions(2)
     const mockConfig = createMockConfig({ clientSide: false })
     setConfig({
       ...mockConfig,
       firebaseAdminInitConfig: undefined,
-      firebaseAdminDefaultCredential: true,
+      useFirebaseAdminDefaultCredential: true,
     })
     const initFirebaseAdminSDK = require('src/initFirebaseAdminSDK').default
     initFirebaseAdminSDK()
@@ -53,7 +53,7 @@ describe('initFirebaseAdminSDK', () => {
     expect(admin.initializeApp).toHaveBeenCalledWith({
       credential: {
         _mockFirebaseDefaultCred: true,
-      }
+      },
     })
   })
 

--- a/src/__tests__/initFirebaseAdminSDK.test.js
+++ b/src/__tests__/initFirebaseAdminSDK.test.js
@@ -13,6 +13,9 @@ beforeEach(() => {
     ...obj,
     _mockFirebaseCert: true,
   }))
+  admin.credential.applicationDefault.mockImplementation(() => ({
+    _mockFirebaseDefaultCred: true,
+  }))
   admin.apps = []
 })
 
@@ -33,6 +36,24 @@ describe('initFirebaseAdminSDK', () => {
         projectId: 'my-example-app',
       },
       databaseURL: 'https://my-example-app.firebaseio.com',
+    })
+  })
+
+  it('calls admin.initializeApp with application default credentials if firebaseAdminDefaultCredential set to true', () => {
+    expect.assertions(2)
+    const mockConfig = createMockConfig({ clientSide: false })
+    setConfig({
+      ...mockConfig,
+      firebaseAdminInitConfig: undefined,
+      firebaseAdminDefaultCredential: true,
+    })
+    const initFirebaseAdminSDK = require('src/initFirebaseAdminSDK').default
+    initFirebaseAdminSDK()
+    expect(admin.credential.applicationDefault).toHaveBeenCalled()
+    expect(admin.initializeApp).toHaveBeenCalledWith({
+      credential: {
+        _mockFirebaseDefaultCred: true,
+      }
     })
   })
 

--- a/src/__tests__/initFirebaseAdminSDK.test.js
+++ b/src/__tests__/initFirebaseAdminSDK.test.js
@@ -83,7 +83,7 @@ describe('initFirebaseAdminSDK', () => {
     expect(() => {
       initFirebaseAdminSDK()
     }).toThrow(
-      'If not initializing the Firebase admin SDK elsewhere, you must provide "firebaseAdminInitConfig" to next-firebase-auth.'
+      'Missing firebase-admin credentials in next-firebase-auth. Set "firebaseAdminInitConfig", "useFirebaseAdminDefaultCredential", or initialize firebase-admin yourself.'
     )
   })
 

--- a/src/initFirebaseAdminSDK.js
+++ b/src/initFirebaseAdminSDK.js
@@ -3,20 +3,20 @@ import { getConfig } from 'src/config'
 
 const initFirebaseAdminSDK = () => {
   if (!admin.apps.length) {
-    const { firebaseAdminInitConfig } = getConfig()
-    if (!firebaseAdminInitConfig) {
+    const { firebaseAdminInitConfig, firebaseAdminDefaultCredential } =
+      getConfig()
+    if (!firebaseAdminInitConfig && !firebaseAdminDefaultCredential) {
       throw new Error(
         'If not initializing the Firebase admin SDK elsewhere, you must provide "firebaseAdminInitConfig" to next-firebase-auth.'
       )
     }
-    // Initialize with credential if provided, otherwise fallback to applicationDefault
     admin.initializeApp({
       ...firebaseAdminInitConfig,
-      credential: firebaseAdminInitConfig.credential
-        ? admin.credential.cert({
-          ...firebaseAdminInitConfig.credential,
-        })
-        : admin.credential.applicationDefault(),
+      credential: firebaseAdminDefaultCredential
+        ? admin.credential.applicationDefault()
+        : admin.credential.cert({
+            ...firebaseAdminInitConfig.credential,
+          }),
     })
   }
   return admin

--- a/src/initFirebaseAdminSDK.js
+++ b/src/initFirebaseAdminSDK.js
@@ -3,16 +3,16 @@ import { getConfig } from 'src/config'
 
 const initFirebaseAdminSDK = () => {
   if (!admin.apps.length) {
-    const { firebaseAdminInitConfig, firebaseAdminDefaultCredential } =
+    const { firebaseAdminInitConfig, useFirebaseAdminDefaultCredential } =
       getConfig()
-    if (!firebaseAdminInitConfig && !firebaseAdminDefaultCredential) {
+    if (!firebaseAdminInitConfig && !useFirebaseAdminDefaultCredential) {
       throw new Error(
-        'If not initializing the Firebase admin SDK elsewhere, you must provide "firebaseAdminInitConfig" to next-firebase-auth.'
+        'Missing firebase-admin credentials in next-firebase-auth. Set "firebaseAdminInitConfig", "useFirebaseAdminDefaultCredential", or initialize firebase-admin yourself.'
       )
     }
     admin.initializeApp({
       ...firebaseAdminInitConfig,
-      credential: firebaseAdminDefaultCredential
+      credential: useFirebaseAdminDefaultCredential
         ? admin.credential.applicationDefault()
         : admin.credential.cert({
             ...firebaseAdminInitConfig.credential,

--- a/src/initFirebaseAdminSDK.js
+++ b/src/initFirebaseAdminSDK.js
@@ -9,11 +9,14 @@ const initFirebaseAdminSDK = () => {
         'If not initializing the Firebase admin SDK elsewhere, you must provide "firebaseAdminInitConfig" to next-firebase-auth.'
       )
     }
+    // Initialize with credential if provided, otherwise fallback to applicationDefault
     admin.initializeApp({
       ...firebaseAdminInitConfig,
-      credential: admin.credential.cert({
-        ...firebaseAdminInitConfig.credential,
-      }),
+      credential: firebaseAdminInitConfig.credential
+        ? admin.credential.cert({
+          ...firebaseAdminInitConfig.credential,
+        })
+        : admin.credential.applicationDefault(),
     })
   }
   return admin


### PR DESCRIPTION
Adds `firebaseAdminDefaultCredential` config option which accepts a boolean - when set to `true` the [application default credentials](https://firebase.google.com/docs/reference/admin/node/firebase-admin.app.md#applicationdefault). This is useful for deploying into Google Cloud Platform environments such as Cloud Functions, Cloud Run, and Compute Engine which have default credentials defined within the environment. This way the keys don't have to be managed/rotated by the user, that is all handled by GCP. Also includes testing and section in README explaining usage.

Instead of just invoking `initializeApp` without any settings as called out in #75, I opted for using `applicationDefault` to combine with other configurations such as `databaseURL`

For firebase-admin v10 the imports would be slightly different (directly from `firebase/app`), so I'm open to making a PR for that version as well.

**NOTE**: With current implementation this will take precedence over `firebaseAdminInitConfig.credential` if it is passed - this makes sense, but wanted to call it out still

### Checks
* [X] Non-breaking API change
* [X] Tests

### Open Questions

* What are thoughts on the config parameter name? Wanted to keep the `firebaseAdmin` prefix, but open to ideas for a more clear name
* Should default credentials be applied by default if `firebaseAdminInitConfig` is not passed? I wanted to prevent breaking changes to the interface (and currently there is an error thrown if this is missing) - makes logical sense but could come later


### Issues
* closes #75