### PR TITLE
Remove thrown errors from token refresh & verification logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,16 @@ const initAuth = () => {
       secure: true, // set this to false in local (non-HTTPS) development
       signed: true,
     },
+    /**
+      * Optional function: handler called if there's an unexpected error while
+      * verifying the user's ID token server-side.
+     */
+    // onVerifyTokenError: (err) => {}
+    /**
+      * Optional function: handler called if there's an unexpected error while
+      * refreshing the user's ID token server-side.
+     */
+    // onTokenRefreshError: (err) => {}
   })
 }
 
@@ -502,6 +512,22 @@ For security, the `maxAge` value must be two weeks or less. Note that `maxAge` i
 > **Note:** The cookies' expirations will be extended automatically when the user loads the Firebase JS SDK.
 >
 > The Firebase JS SDK is the source of truth for authentication, so if the cookies expire but the user is still authed with Firebase, the cookies will be automatically set again when the user loads the Firebase JS SDK—but the user will not be authed during SSR on that first request.
+
+#### onVerifyTokenError
+
+`Function` (optional)
+
+Error handler that will be called if there's an unexpected error while verifying the user's ID token server-side. It will receive a [Firebase auth error](https://firebase.google.com/docs/reference/node/firebase.auth.Error).
+
+This library will **not** throw when it cannot verify an ID token. Instead, it will provide an unauthenticated user to the app. It will typically handle common auth-related errors such as `auth/id-token-expired` and `auth/user-disabled` without throwing. See [#366](https://github.com/gladly-team/next-firebase-auth/issues/366) and [#174](https://github.com/gladly-team/next-firebase-auth/issues/174) for additional background.
+
+#### onTokenRefreshError
+
+`Function` (optional)
+
+Error handler that will be called if there's an unexpected error while refreshing the user's ID token server-side.
+
+This library will **not** throw when it cannot refresh an ID token. Instead, it will provide an unauthenticated user to the app. See [#366](https://github.com/gladly-team/next-firebase-auth/issues/366) and [#174](https://github.com/gladly-team/next-firebase-auth/issues/174) for additional background.
 
 ## Types
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -57,6 +57,8 @@ interface InitConfig {
   appPageURL?: PageURL
   loginAPIEndpoint?: string
   logoutAPIEndpoint?: string
+  onVerifyTokenError?: (error: unknown) => void,
+  onTokenRefreshError?: (error: unknown) => void,
   tokenChangedHandler?: (user: AuthUser) => void
   firebaseAdminInitConfig?: {
     credential: {

--- a/index.d.ts
+++ b/index.d.ts
@@ -57,8 +57,8 @@ interface InitConfig {
   appPageURL?: PageURL
   loginAPIEndpoint?: string
   logoutAPIEndpoint?: string
-  onVerifyTokenError?: (error: unknown) => void,
-  onTokenRefreshError?: (error: unknown) => void,
+  onVerifyTokenError?: (error: unknown) => void
+  onTokenRefreshError?: (error: unknown) => void
   tokenChangedHandler?: (user: AuthUser) => void
   firebaseAdminInitConfig?: {
     credential: {

--- a/src/__tests__/config.test.js
+++ b/src/__tests__/config.test.js
@@ -524,4 +524,60 @@ describe('config', () => {
       setConfig(mockConfig)
     }).not.toThrow()
   })
+
+  it('does not throw if onVerifyTokenError is undefined', () => {
+    expect.assertions(1)
+    const { setConfig } = require('src/config')
+    const mockConfigDefault = createMockConfig()
+    const mockConfig = {
+      ...mockConfigDefault,
+      onVerifyTokenError: undefined,
+    }
+    expect(() => {
+      setConfig(mockConfig)
+    }).not.toThrow()
+  })
+
+  it('throws if onVerifyTokenError is not a function', () => {
+    expect.assertions(1)
+    const { setConfig } = require('src/config')
+    const mockConfigDefault = createMockConfig()
+    const mockConfig = {
+      ...mockConfigDefault,
+      onVerifyTokenError: 'no errors please',
+    }
+    expect(() => {
+      setConfig(mockConfig)
+    }).toThrow(
+      'Invalid next-firebase-auth options: The "onVerifyTokenError" setting must be a function.'
+    )
+  })
+
+  it('does not throw if onTokenRefreshError is undefined', () => {
+    expect.assertions(1)
+    const { setConfig } = require('src/config')
+    const mockConfigDefault = createMockConfig()
+    const mockConfig = {
+      ...mockConfigDefault,
+      onTokenRefreshError: undefined,
+    }
+    expect(() => {
+      setConfig(mockConfig)
+    }).not.toThrow()
+  })
+
+  it('throws if onTokenRefreshError is not a function', () => {
+    expect.assertions(1)
+    const { setConfig } = require('src/config')
+    const mockConfigDefault = createMockConfig()
+    const mockConfig = {
+      ...mockConfigDefault,
+      onTokenRefreshError: false,
+    }
+    expect(() => {
+      setConfig(mockConfig)
+    }).toThrow(
+      'Invalid next-firebase-auth options: The "onTokenRefreshError" setting must be a function.'
+    )
+  })
 })

--- a/src/__tests__/config.test.js
+++ b/src/__tests__/config.test.js
@@ -458,70 +458,70 @@ describe('config', () => {
       'The "logoutAPIEndpoint" setting should not be set if you are using a "tokenChangedHandler".'
     )
   })
-})
 
-it('should throw if the config.firebaseAuthEmulator has a http or https prefix', () => {
-  expect.assertions(1)
-  const { setConfig } = require('src/config')
-  const mockConfigDefault = createMockConfig()
-  const mockConfig = {
-    ...mockConfigDefault,
-    firebaseAuthEmulatorHost: 'http://localhost:9099',
-  }
-  expect(() => {
-    setConfig(mockConfig)
-  }).toThrow(
-    'Invalid next-firebase-auth options: The firebaseAuthEmulatorHost should be set without a prefix (e.g., localhost:9099)'
-  )
-})
+  it('throws if the config.firebaseAuthEmulator has a http or https prefix', () => {
+    expect.assertions(1)
+    const { setConfig } = require('src/config')
+    const mockConfigDefault = createMockConfig()
+    const mockConfig = {
+      ...mockConfigDefault,
+      firebaseAuthEmulatorHost: 'http://localhost:9099',
+    }
+    expect(() => {
+      setConfig(mockConfig)
+    }).toThrow(
+      'Invalid next-firebase-auth options: The firebaseAuthEmulatorHost should be set without a prefix (e.g., localhost:9099)'
+    )
+  })
 
-it('[server-side] throws if config.firebaseAuthEmulatorHost is set, but not the FIREBASE_AUTH_EMULATOR_HOST env var', () => {
-  expect.assertions(1)
-  const isClientSide = require('src/isClientSide').default
-  isClientSide.mockReturnValue(false)
-  const { setConfig } = require('src/config')
-  const mockConfigDefault = createMockConfig()
-  const mockConfig = {
-    ...mockConfigDefault,
-    firebaseAuthEmulatorHost: 'localhost:9099',
-  }
-  expect(() => {
-    setConfig(mockConfig)
-  }).toThrow(
-    'The "FIREBASE_AUTH_EMULATOR_HOST" environment variable should be set if you are using the "firebaseAuthEmulatorHost" option'
-  )
-})
+  it('[server-side] throws if config.firebaseAuthEmulatorHost is set, but not the FIREBASE_AUTH_EMULATOR_HOST env var', () => {
+    expect.assertions(1)
+    const isClientSide = require('src/isClientSide').default
+    isClientSide.mockReturnValue(false)
+    const { setConfig } = require('src/config')
+    const mockConfigDefault = createMockConfig()
+    const mockConfig = {
+      ...mockConfigDefault,
+      firebaseAuthEmulatorHost: 'localhost:9099',
+    }
+    expect(() => {
+      setConfig(mockConfig)
+    }).toThrow(
+      'The "FIREBASE_AUTH_EMULATOR_HOST" environment variable should be set if you are using the "firebaseAuthEmulatorHost" option'
+    )
+  })
 
-it('[server-side] throws if the FIREBASE_AUTH_EMULATOR_HOST env var differs from the one set in the config', () => {
-  expect.assertions(1)
-  const isClientSide = require('src/isClientSide').default
-  isClientSide.mockReturnValue(false)
-  const { setConfig } = require('src/config')
-  const mockConfigDefault = createMockConfig()
-  const mockConfig = {
-    ...mockConfigDefault,
-    firebaseAuthEmulatorHost: 'localhost:9099',
-  }
-  process.env.FIREBASE_AUTH_EMULATOR_HOST = 'localhost:8088'
-  expect(() => {
-    setConfig(mockConfig)
-  }).toThrow(
-    'The "FIREBASE_AUTH_EMULATOR_HOST" environment variable should be the same as the host set in the config'
-  )
-})
+  it('[server-side] throws if the FIREBASE_AUTH_EMULATOR_HOST env var differs from the one set in the config', () => {
+    expect.assertions(1)
+    const isClientSide = require('src/isClientSide').default
+    isClientSide.mockReturnValue(false)
+    const { setConfig } = require('src/config')
+    const mockConfigDefault = createMockConfig()
+    const mockConfig = {
+      ...mockConfigDefault,
+      firebaseAuthEmulatorHost: 'localhost:9099',
+    }
+    process.env.FIREBASE_AUTH_EMULATOR_HOST = 'localhost:8088'
+    expect(() => {
+      setConfig(mockConfig)
+    }).toThrow(
+      'The "FIREBASE_AUTH_EMULATOR_HOST" environment variable should be the same as the host set in the config'
+    )
+  })
 
-it('[server-side] should not throw if the FIREBASE_AUTH_EMULATOR_HOST env variable is set and matches the one set in the config', () => {
-  expect.assertions(1)
-  const isClientSide = require('src/isClientSide').default
-  isClientSide.mockReturnValue(false)
-  const { setConfig } = require('src/config')
-  const mockConfigDefault = createMockConfig()
-  const mockConfig = {
-    ...mockConfigDefault,
-    firebaseAuthEmulatorHost: 'localhost:9099',
-  }
-  process.env.FIREBASE_AUTH_EMULATOR_HOST = 'localhost:9099'
-  expect(() => {
-    setConfig(mockConfig)
-  }).not.toThrow()
+  it('[server-side] should not throw if the FIREBASE_AUTH_EMULATOR_HOST env variable is set and matches the one set in the config', () => {
+    expect.assertions(1)
+    const isClientSide = require('src/isClientSide').default
+    isClientSide.mockReturnValue(false)
+    const { setConfig } = require('src/config')
+    const mockConfigDefault = createMockConfig()
+    const mockConfig = {
+      ...mockConfigDefault,
+      firebaseAuthEmulatorHost: 'localhost:9099',
+    }
+    process.env.FIREBASE_AUTH_EMULATOR_HOST = 'localhost:9099'
+    expect(() => {
+      setConfig(mockConfig)
+    }).not.toThrow()
+  })
 })

--- a/src/__tests__/config.test.js
+++ b/src/__tests__/config.test.js
@@ -40,6 +40,8 @@ describe('config', () => {
     setConfig(mockConfig)
     const expectedConfig = {
       ...mockConfig,
+      onVerifyTokenError: expect.any(Function),
+      onTokenRefreshError: expect.any(Function),
       cookies: {
         ...mockConfig.cookies,
         keys: ['hidden'],

--- a/src/__tests__/config.test.js
+++ b/src/__tests__/config.test.js
@@ -540,6 +540,16 @@ describe('config', () => {
     }).not.toThrow()
   })
 
+  it('defaults onVerifyTokenError to a function', () => {
+    expect.assertions(1)
+    const { getConfig, setConfig } = require('src/config')
+    const mockConfigDefault = createMockConfig()
+    delete mockConfigDefault.onVerifyTokenError
+    setConfig(mockConfigDefault)
+    const config = getConfig()
+    expect(typeof config.onVerifyTokenError).toEqual('function')
+  })
+
   it('throws if onVerifyTokenError is not a function', () => {
     expect.assertions(1)
     const { setConfig } = require('src/config')
@@ -566,6 +576,16 @@ describe('config', () => {
     expect(() => {
       setConfig(mockConfig)
     }).not.toThrow()
+  })
+
+  it('defaults onTokenRefreshError to a function', () => {
+    expect.assertions(1)
+    const { getConfig, setConfig } = require('src/config')
+    const mockConfigDefault = createMockConfig()
+    delete mockConfigDefault.onTokenRefreshError
+    setConfig(mockConfigDefault)
+    const config = getConfig()
+    expect(typeof config.onTokenRefreshError).toEqual('function')
   })
 
   it('throws if onTokenRefreshError is not a function', () => {

--- a/src/__tests__/firebaseAdmin.test.js
+++ b/src/__tests__/firebaseAdmin.test.js
@@ -38,6 +38,7 @@ const googleCustomTokenEndpoint =
 
 describe('verifyIdToken', () => {
   it('returns an AuthUser', async () => {
+    expect.assertions(1)
     const { verifyIdToken } = require('src/firebaseAdmin')
     const mockFirebaseUser = createMockFirebaseUserAdminSDK()
     const expectedReturn = createAuthUser({
@@ -56,6 +57,7 @@ describe('verifyIdToken', () => {
   })
 
   it('returns an AuthUser with the same token when the token has not expired', async () => {
+    expect.assertions(1)
     const { verifyIdToken } = require('src/firebaseAdmin')
     const mockFirebaseUser = createMockFirebaseUserAdminSDK()
     const admin = getFirebaseAdminApp()
@@ -66,6 +68,7 @@ describe('verifyIdToken', () => {
   })
 
   it('returns an AuthUser with a new token when the token is refreshed because of a Firebase auth/id-token-expired error', async () => {
+    expect.assertions(1)
     const { verifyIdToken } = require('src/firebaseAdmin')
 
     // Mock the behavior of refreshing the token.
@@ -100,6 +103,7 @@ describe('verifyIdToken', () => {
   })
 
   it('returns an AuthUser with a new token when the token is refreshed because of a Firebase auth/argument-error error', async () => {
+    expect.assertions(1)
     const { verifyIdToken } = require('src/firebaseAdmin')
 
     // Mock the behavior of refreshing the token.
@@ -134,6 +138,7 @@ describe('verifyIdToken', () => {
   })
 
   it('calls the Google token refresh endpoint with the public Firebase API key as a query parameter value', async () => {
+    expect.assertions(1)
     const { verifyIdToken } = require('src/firebaseAdmin')
 
     // Set the Firebase API key.
@@ -167,6 +172,7 @@ describe('verifyIdToken', () => {
   })
 
   it('passes the expected fetch options when refreshing the token', async () => {
+    expect.assertions(1)
     const { verifyIdToken } = require('src/firebaseAdmin')
 
     // Mock that the original token is expired but a new token works.
@@ -195,6 +201,7 @@ describe('verifyIdToken', () => {
   })
 
   it('returns an unauthenticated AuthUser if verifying the token fails with auth/invalid-user-token', async () => {
+    expect.assertions(2)
     const { verifyIdToken } = require('src/firebaseAdmin')
 
     const expiredTokenErr = new Error('Mock error message.')
@@ -215,6 +222,7 @@ describe('verifyIdToken', () => {
   })
 
   it('returns an unauthenticated AuthUser if verifying the token fails with auth/user-token-expired', async () => {
+    expect.assertions(2)
     const { verifyIdToken } = require('src/firebaseAdmin')
 
     const expiredTokenErr = new Error('Mock error message.')
@@ -235,6 +243,7 @@ describe('verifyIdToken', () => {
   })
 
   it('returns an unauthenticated AuthUser if verifying the token fails with auth/user-disabled', async () => {
+    expect.assertions(2)
     const { verifyIdToken } = require('src/firebaseAdmin')
 
     const expiredTokenErr = new Error('Mock error message.')
@@ -255,6 +264,7 @@ describe('verifyIdToken', () => {
   })
 
   it('returns an unauthenticated AuthUser if there is no refresh token and the id token has expired', async () => {
+    expect.assertions(2)
     const { verifyIdToken } = require('src/firebaseAdmin')
 
     const expiredTokenErr = new Error('Mock error message.')
@@ -275,6 +285,7 @@ describe('verifyIdToken', () => {
   })
 
   it('does not throw if there is an error refreshing the token', async () => {
+    expect.assertions(1)
     const { verifyIdToken } = require('src/firebaseAdmin')
     global.fetch.mockImplementation(async () => ({
       ...createMockFetchResponse(),
@@ -419,6 +430,7 @@ describe('verifyIdToken', () => {
 
 describe('getCustomIdAndRefreshTokens', () => {
   it("passes the Firebase user's ID (from verifyIdToken) to createCustomToken", async () => {
+    expect.assertions(1)
     const { getCustomIdAndRefreshTokens } = require('src/firebaseAdmin')
     const mockFirebaseUser = createMockFirebaseUserAdminSDK()
     const admin = getFirebaseAdminApp()
@@ -431,6 +443,7 @@ describe('getCustomIdAndRefreshTokens', () => {
   })
 
   it('calls the public google endpoint if the firebaseAuthEmulatorHost is not set to get a custom token, including the public Firebase API key as a URL parameter', async () => {
+    expect.assertions(1)
     const { getCustomIdAndRefreshTokens } = require('src/firebaseAdmin')
 
     // Set the Firebase API key.
@@ -485,6 +498,7 @@ describe('getCustomIdAndRefreshTokens', () => {
   })
 
   it('uses the expected fetch options when calling to get a custom token', async () => {
+    expect.assertions(1)
     const { getCustomIdAndRefreshTokens } = require('src/firebaseAdmin')
     const mockFirebaseUser = createMockFirebaseUserAdminSDK()
     const admin = getFirebaseAdminApp()
@@ -502,6 +516,7 @@ describe('getCustomIdAndRefreshTokens', () => {
   })
 
   it('returns the expected token values', async () => {
+    expect.assertions(1)
     const { getCustomIdAndRefreshTokens } = require('src/firebaseAdmin')
 
     // Mock the behavior of getting a custom token.
@@ -527,6 +542,7 @@ describe('getCustomIdAndRefreshTokens', () => {
   })
 
   it('returns the expected AuthUser value', async () => {
+    expect.assertions(1)
     const { getCustomIdAndRefreshTokens } = require('src/firebaseAdmin')
 
     // Mock the behavior of getting a custom token.
@@ -557,6 +573,7 @@ describe('getCustomIdAndRefreshTokens', () => {
   })
 
   it('throws if fetching a custom token fails', async () => {
+    expect.assertions(1)
     const { getCustomIdAndRefreshTokens } = require('src/firebaseAdmin')
 
     // Mock the behavior of getting a custom token.

--- a/src/__tests__/firebaseAdmin.test.js
+++ b/src/__tests__/firebaseAdmin.test.js
@@ -353,7 +353,7 @@ describe('verifyIdToken', () => {
   })
 
   it("returns an unauthenticated AuthUser if Firebase admin's verifyIdToken throws something other than an expired token error", async () => {
-    expect.assertions(1)
+    expect.assertions(2)
     const { verifyIdToken } = require('src/firebaseAdmin')
     global.fetch.mockImplementation(async (endpoint) => {
       if (endpoint.indexOf(googleRefreshTokenEndpoint) === 0) {
@@ -397,7 +397,7 @@ describe('verifyIdToken', () => {
   })
 
   it("returns an unauthenticated AuthUser if Firebase admin's verifyIdToken throws an expired token error for the refreshed token", async () => {
-    expect.assertions(1)
+    expect.assertions(2)
     const { verifyIdToken } = require('src/firebaseAdmin')
 
     // Mock that verifyIdToken throws a "token expired" error even for

--- a/src/__tests__/firebaseAdmin.test.js
+++ b/src/__tests__/firebaseAdmin.test.js
@@ -338,7 +338,6 @@ describe('verifyIdToken', () => {
     })
 
     const { verifyIdToken } = require('src/firebaseAdmin')
-    const { onTokenRefreshError } = getConfig()
     global.fetch.mockImplementation(async () => ({
       ...createMockFetchResponse(),
       ok: false,
@@ -359,7 +358,8 @@ describe('verifyIdToken', () => {
       }
     })
 
-    // Not awaiting verifyIdToken here
+    // Not awaiting verifyIdToken here. We'll rely on `expect.assertions`.
+    // eslint-disable-next-line jest/valid-expect-in-promise
     verifyIdToken('some-token', 'my-refresh-token').then(() => {
       expect(isResolved).toBe(true)
     })
@@ -443,7 +443,6 @@ describe('verifyIdToken', () => {
     })
 
     const { verifyIdToken } = require('src/firebaseAdmin')
-    const { onVerifyTokenError } = getConfig()
     global.fetch.mockImplementation(async (endpoint) => {
       if (endpoint.indexOf(googleRefreshTokenEndpoint) === 0) {
         return {
@@ -461,7 +460,8 @@ describe('verifyIdToken', () => {
       throw otherErr
     })
 
-    // Not awaiting verifyIdToken here
+    // Not awaiting verifyIdToken here. We'll rely on `expect.assertions`.
+    // eslint-disable-next-line jest/valid-expect-in-promise
     verifyIdToken('some-token', 'my-refresh-token').then(() => {
       expect(isResolved).toBe(true)
     })
@@ -537,7 +537,6 @@ describe('verifyIdToken', () => {
     })
 
     const { verifyIdToken } = require('src/firebaseAdmin')
-    const { onVerifyTokenError } = getConfig()
 
     // Mock that verifyIdToken throws a "token expired" error even for
     // the refreshed token, for some reason.
@@ -550,7 +549,8 @@ describe('verifyIdToken', () => {
       throw expiredTokenErr
     })
 
-    // Not awaiting verifyIdToken here
+    // Not awaiting verifyIdToken here. We'll rely on `expect.assertions`.
+    // eslint-disable-next-line jest/valid-expect-in-promise
     verifyIdToken('some-token', 'my-refresh-token').then(() => {
       expect(isResolved).toBe(true)
     })

--- a/src/config.js
+++ b/src/config.js
@@ -61,6 +61,8 @@ const defaultConfig = {
 const validateConfig = (mergedConfig) => {
   const errorMessages = []
 
+  // The config should have *either* a tokenChangedHandler *or* the API
+  // endpoints for login/logout.
   if (mergedConfig.tokenChangedHandler) {
     if (mergedConfig.loginAPIEndpoint) {
       errorMessages.push(
@@ -94,7 +96,7 @@ const validateConfig = (mergedConfig) => {
     )
   }
 
-  // make sure the host address is set correctly.
+  // Make sure the host address is set correctly.
   if (
     mergedConfig.firebaseAuthEmulatorHost &&
     mergedConfig.firebaseAuthEmulatorHost.startsWith('http')
@@ -112,8 +114,11 @@ const validateConfig = (mergedConfig) => {
     keys.length &&
     (keys.filter ? keys.filter((item) => item !== undefined).length : true)
 
-  // Validate client-side config.
+  // Validate config values that differ between client and server context.
   if (isClientSide()) {
+    /**
+     * START: config specific to client side
+     */
     if (
       mergedConfig.firebaseAdminInitConfig &&
       mergedConfig.firebaseAdminInitConfig.credential &&
@@ -128,8 +133,13 @@ const validateConfig = (mergedConfig) => {
         'The "cookies.keys" setting should not be available on the client side.'
       )
     }
-    // Validate server-side config.
+    /**
+     * END: config specific to client side
+     */
   } else {
+    /**
+     * START: config specific to server side
+     */
     if (!mergedConfig.cookies.name) {
       errorMessages.push(
         'The "cookies.name" setting is required on the server side.'
@@ -140,8 +150,9 @@ const validateConfig = (mergedConfig) => {
         'The "cookies.keys" setting must be set if "cookies.signed" is true.'
       )
     }
-    // check if the AUTH_EMULATOR_HOST_VARIABLE is set if the user has
-    // set the config to use the authEmultor
+
+    // Verify that the AUTH_EMULATOR_HOST_VARIABLE is set if the user has
+    // provided the emulator host in the config.
     if (mergedConfig.firebaseAuthEmulatorHost) {
       if (!process.env.FIREBASE_AUTH_EMULATOR_HOST) {
         errorMessages.push(
@@ -156,6 +167,7 @@ const validateConfig = (mergedConfig) => {
         )
       }
     }
+
     // Limit the max cookie age to two weeks for security. This matches
     // Firebase's limit for user identity cookies:
     // https://firebase.google.com/docs/auth/admin/manage-cookies
@@ -166,7 +178,11 @@ const validateConfig = (mergedConfig) => {
         `The "cookies.maxAge" setting must be less than two weeks (${TWO_WEEKS_IN_MS} ms).`
       )
     }
+    /**
+     * END: config specific to server side
+     */
   }
+
   return {
     isValid: errorMessages.length === 0,
     errors: errorMessages,

--- a/src/config.js
+++ b/src/config.js
@@ -17,6 +17,12 @@ const defaultConfig = {
   // Optional function: callback handler to call on auth state
   // changes. Replaces need for loginAPIEndpoint and logoutAPIEndpoint
   tokenChangedHandler: undefined,
+  // Optional function: handler called if there are unexpected errors while
+  // verifying the user's ID token server-side.
+  onVerifyTokenError: () => {},
+  // Optional function: handler called if there are unexpected errors while
+  // refreshing the user's ID token server-side.
+  onTokenRefreshError: () => {},
   // Optional string: the URL to navigate to when the user
   // needs to log in.
   authPageURL: undefined,
@@ -103,6 +109,19 @@ const validateConfig = (mergedConfig) => {
   ) {
     errorMessages.push(
       'The firebaseAuthEmulatorHost should be set without a prefix (e.g., localhost:9099)'
+    )
+  }
+
+  // Ensure error callbacks are functions or undefined.
+  const funcOrUndefArr = ['function', 'undefined']
+  if (funcOrUndefArr.indexOf(typeof mergedConfig.onVerifyTokenError) < 0) {
+    errorMessages.push(
+      'Invalid next-firebase-auth options: The "onVerifyTokenError" setting must be a function.'
+    )
+  }
+  if (funcOrUndefArr.indexOf(typeof mergedConfig.onTokenRefreshError) < 0) {
+    errorMessages.push(
+      'Invalid next-firebase-auth options: The "onTokenRefreshError" setting must be a function.'
     )
   }
 

--- a/src/firebaseAdmin.js
+++ b/src/firebaseAdmin.js
@@ -81,14 +81,14 @@ export const verifyIdToken = async (token, refreshToken = null) => {
             newTokenFailure = true
 
             // Call developer-provided error callback.
-            onTokenRefreshError(refreshErr)
+            await onTokenRefreshError(refreshErr)
           }
 
           if (!newTokenFailure) {
             try {
               firebaseUser = await admin.auth().verifyIdToken(newToken)
             } catch (verifyErr) {
-              onVerifyTokenError(verifyErr)
+              await onVerifyTokenError(verifyErr)
             }
           }
 
@@ -118,7 +118,7 @@ export const verifyIdToken = async (token, refreshToken = null) => {
         firebaseUser = null
 
         // Call developer-provided error callback.
-        onVerifyTokenError(e)
+        await onVerifyTokenError(e)
     }
   }
   const AuthUser = createAuthUser({

--- a/src/testHelpers/createMockConfig.js
+++ b/src/testHelpers/createMockConfig.js
@@ -1,5 +1,8 @@
 /* eslint-env jest */
 
+const onVerifyTokenError = () => {}
+const onTokenRefreshError = () => {}
+
 const createMockConfig = ({ clientSide } = {}) => {
   // eslint-disable-next-line global-require
   const isClientSide = require('src/isClientSide').default
@@ -9,6 +12,8 @@ const createMockConfig = ({ clientSide } = {}) => {
     debug: false,
     loginAPIEndpoint: 'https://example.com/api/login',
     logoutAPIEndpoint: 'https://example.com/api/logout',
+    onVerifyTokenError,
+    onTokenRefreshError,
     authPageURL: '/login',
     appPageURL: '/',
     firebaseAdminInitConfig: {

--- a/src/testHelpers/createMockConfig.js
+++ b/src/testHelpers/createMockConfig.js
@@ -1,8 +1,5 @@
 /* eslint-env jest */
 
-const onVerifyTokenError = () => {}
-const onTokenRefreshError = () => {}
-
 const createMockConfig = ({ clientSide } = {}) => {
   // eslint-disable-next-line global-require
   const isClientSide = require('src/isClientSide').default
@@ -12,8 +9,8 @@ const createMockConfig = ({ clientSide } = {}) => {
     debug: false,
     loginAPIEndpoint: 'https://example.com/api/login',
     logoutAPIEndpoint: 'https://example.com/api/logout',
-    onVerifyTokenError,
-    onTokenRefreshError,
+    onVerifyTokenError: jest.fn(),
+    onTokenRefreshError: jest.fn(),
     authPageURL: '/login',
     appPageURL: '/',
     firebaseAdminInitConfig: {


### PR DESCRIPTION
Closes #366.

* Never throw an error when verifying or refreshing an ID token
* Add optional error callbacks to the config to allow the developer to easily handle unexpected token errors