### PR TITLE
Add useFirebaseAdminDefaultCredential type definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -67,6 +67,7 @@ interface InitConfig {
   tokenChangedHandler?: (user: AuthUser) => void
   onLoginRequestError?: (error: unknown) => void
   onLogoutRequestError?: (error: unknown) => void
+  useFirebaseAdminDefaultCredential?: boolean
   firebaseAdminInitConfig?: {
     credential: {
       projectId: string


### PR DESCRIPTION
- Break down commit from #448.

- Currently, `useFirebaseAdminDefaultCredential` is not in the `InitConfig` interface, so this causes `Object literal may only specify known properties` in TypeScript projects. This PR adds that property to the `InitConfig` interface.