### PR TITLE
[v1.x] fix: Add useFirebaseAdminDefaultCredential type definition (#451)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -74,6 +74,7 @@ interface InitConfig {
   tokenChangedHandler?: (user: AuthUser) => void
   onLoginRequestError?: (error: unknown) => void
   onLogoutRequestError?: (error: unknown) => void
+  useFirebaseAdminDefaultCredential?: boolean
   firebaseAdminInitConfig?: {
     credential: {
       projectId: string


### PR DESCRIPTION
Cherry-pick #451 onto v1.x.