### PR TITLE
Support running in a backend-only context

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ const initAuth = () => {
   init({
     authPageURL: '/auth',
     appPageURL: '/',
-    loginAPIEndpoint: '/api/login', // required
-    logoutAPIEndpoint: '/api/logout', // required
+    loginAPIEndpoint: '/api/login',
+    logoutAPIEndpoint: '/api/logout',
     onLoginRequestError: (err) => {
       console.error(err)
     },
@@ -449,15 +449,11 @@ The default URL to navigate to when `withAuthUser` or `withAuthUserTokenSSR` nee
 
 The API endpoint this module will call when the auth state changes for an authenticated Firebase user.
 
-Required unless a custom `tokenChangedHandler` is set, in which case it cannot be defined.
-
 #### logoutAPIEndpoint
 
 `String`
 
 The API endpoint this module will call when the auth state changes for an unauthenticated Firebase user.
-
-Required unless a custom `tokenChangedHandler` is set, in which case it cannot be defined.
 
 #### onLoginRequestError
 
@@ -519,7 +515,7 @@ When true, `firebase-admin` will implicitly find your hosting environment servic
 
 `Object`
 
-Configuration passed to the Firebase JS SDK's [`initializeApp`](https://firebase.google.com/docs/reference/node/firebase#initializeapp). The `firebaseClientInitConfig.apiKey` value is **always required**. Other properties are required unless you initialize the `firebase` app yourself before initializing `next-firebase-auth`.
+Configuration passed to the Firebase JS SDK's [`initializeApp`](https://firebase.google.com/docs/reference/node/firebase#initializeapp). The `firebaseClientInitConfig.apiKey` value is **always required**. Other properties are required unless you initialize the `firebase` app yourself before initializing `next-firebase-auth` (or, less commonly, if you're running `next-firebase-auth` solely on the server side).
 
 #### cookies
 

--- a/package.json
+++ b/package.json
@@ -92,6 +92,20 @@
     "react": ">=16.8.0 <19",
     "react-dom": ">=16.8.0 <19"
   },
+  "peerDependenciesMeta": {
+    "firebase": {
+      "optional": true
+    },
+    "next": {
+      "optional": true
+    },
+    "react": {
+      "optional": true
+    },
+    "react-dom": {
+      "optional": true
+    }
+  },
   "dependencies": {
     "cookies": "^0.8.0",
     "hoist-non-react-statics": "^3.3.2"

--- a/src/__tests__/config.test.js
+++ b/src/__tests__/config.test.js
@@ -235,7 +235,7 @@ describe('config: server side', () => {
     }).not.toThrow()
   })
 
-  it('throws if the tokenChangedHandler and logoutAPIEndpoint are not defined', () => {
+  it('does not throw if the tokenChangedHandler and logoutAPIEndpoint are not defined', () => {
     expect.assertions(1)
     const { setConfig } = require('src/config')
     const mockConfigDefault = createMockConfig()
@@ -636,6 +636,21 @@ describe('config: client side', () => {
         ...mockConfigDefault.cookies,
         keys: [undefined, undefined],
       },
+    }
+    expect(() => {
+      setConfig(mockConfig)
+    }).not.toThrow()
+  })
+
+  it('does not throw if the tokenChangedHandler is set and loginAPIEndpoint/logoutAPIEndpoint are not defined', () => {
+    expect.assertions(1)
+    const { setConfig } = require('src/config')
+    const mockConfigDefault = createMockConfig()
+    const mockConfig = {
+      ...mockConfigDefault,
+      tokenChangedHandler: () => {},
+      loginAPIEndpoint: undefined,
+      logoutAPIEndpoint: undefined,
     }
     expect(() => {
       setConfig(mockConfig)

--- a/src/__tests__/config.test.js
+++ b/src/__tests__/config.test.js
@@ -448,7 +448,7 @@ describe('config: client side', () => {
     isClientSide.mockReturnValue(true)
   })
 
-  it('[client-side] returns the set config with defaults', () => {
+  it('returns the set config with defaults', () => {
     expect.assertions(1)
     const { getConfig, setConfig } = require('src/config')
     const mockConfig = {
@@ -475,7 +475,7 @@ describe('config: client side', () => {
     expect(getConfig()).toEqual(expectedConfig)
   })
 
-  it('[client-side] throws if the user does not define the firebaseClientInitConfig', () => {
+  it('throws if the user does not define the firebaseClientInitConfig', () => {
     expect.assertions(1)
     const { setConfig } = require('src/config')
     const mockConfig = {
@@ -489,7 +489,7 @@ describe('config: client side', () => {
     )
   })
 
-  it('[client-side] throws if the user provides firebaseClientInitConfig without an API key', () => {
+  it('throws if the user provides firebaseClientInitConfig without an API key', () => {
     expect.assertions(1)
     const { setConfig } = require('src/config')
     const mockConfig = {
@@ -505,7 +505,7 @@ describe('config: client side', () => {
     )
   })
 
-  it('[client-side] does not throw if the user provides firebaseAdminInitConfig on the client side, as long as the private key is not set', () => {
+  it('does not throw if the user provides firebaseAdminInitConfig on the client side, as long as the private key is not set', () => {
     expect.assertions(1)
     const { setConfig } = require('src/config')
     const mockConfig = {
@@ -524,7 +524,7 @@ describe('config: client side', () => {
     }).not.toThrow()
   })
 
-  it('[client-side] throws if the user provides firebaseAdminInitConfig.credential.privateKey on the client side', () => {
+  it('throws if the user provides firebaseAdminInitConfig.credential.privateKey on the client side', () => {
     expect.assertions(1)
     const { setConfig } = require('src/config')
     const mockConfig = {
@@ -545,7 +545,7 @@ describe('config: client side', () => {
     )
   })
 
-  it('[client-side] throws if the user provides a cookies.keys value', () => {
+  it('throws if the user provides a cookies.keys value', () => {
     expect.assertions(1)
     const { setConfig } = require('src/config')
     const mockConfigDefault = createMockConfig()
@@ -563,7 +563,7 @@ describe('config: client side', () => {
     )
   })
 
-  it('[client-side] throws if the user provides a cookies.keys array', () => {
+  it('throws if the user provides a cookies.keys array', () => {
     expect.assertions(1)
     const { setConfig } = require('src/config')
     const mockConfigDefault = createMockConfig()
@@ -581,7 +581,7 @@ describe('config: client side', () => {
     )
   })
 
-  it('[client-side] does not throw if the user provides an undefined cookies.keys value', () => {
+  it('does not throw if the user provides an undefined cookies.keys value', () => {
     expect.assertions(1)
     const { setConfig } = require('src/config')
     const mockConfigDefault = createMockConfig()
@@ -597,7 +597,7 @@ describe('config: client side', () => {
     }).not.toThrow()
   })
 
-  it('[client-side] does not throw if the user provides an empty cookies.keys array', () => {
+  it('does not throw if the user provides an empty cookies.keys array', () => {
     expect.assertions(1)
     const { setConfig } = require('src/config')
     const mockConfigDefault = createMockConfig()
@@ -613,7 +613,7 @@ describe('config: client side', () => {
     }).not.toThrow()
   })
 
-  it('[client-side] does not throw if the user provides a cookies.keys array with only undefined values', () => {
+  it('does not throw if the user provides a cookies.keys array with only undefined values', () => {
     expect.assertions(1)
     const { setConfig } = require('src/config')
     const mockConfigDefault = createMockConfig()

--- a/src/__tests__/config.test.js
+++ b/src/__tests__/config.test.js
@@ -222,7 +222,7 @@ describe('config: server side', () => {
     }).not.toThrow()
   })
 
-  it('throws if the tokenChangedHandler and loginAPIEndpoint are not defined', () => {
+  it('does not throw if the tokenChangedHandler and loginAPIEndpoint are not defined', () => {
     expect.assertions(1)
     const { setConfig } = require('src/config')
     const mockConfigDefault = createMockConfig()
@@ -232,9 +232,7 @@ describe('config: server side', () => {
     }
     expect(() => {
       setConfig(mockConfig)
-    }).toThrow(
-      'Invalid next-firebase-auth options: The "loginAPIEndpoint" setting is required.'
-    )
+    }).not.toThrow()
   })
 
   it('throws if the tokenChangedHandler and logoutAPIEndpoint are not defined', () => {
@@ -247,9 +245,7 @@ describe('config: server side', () => {
     }
     expect(() => {
       setConfig(mockConfig)
-    }).toThrow(
-      'Invalid next-firebase-auth options: The "logoutAPIEndpoint" setting is required.'
-    )
+    }).not.toThrow()
   })
 
   it('throws if both the tokenChangedHandler and loginAPIEndpoint are defined', () => {
@@ -437,6 +433,23 @@ describe('config: server side', () => {
     }).toThrow(
       'Invalid next-firebase-auth options: The "onTokenRefreshError" setting must be a function.'
     )
+  })
+
+  it('does not throw with the expected minimalistic config for a Node backend', () => {
+    expect.assertions(1)
+    const { setConfig } = require('src/config')
+    const minimalConfig = {
+      firebaseClientInitConfig: {
+        apiKey: 'fakeAPIKey123',
+      },
+      cookies: {
+        name: 'someExample',
+        signed: false,
+      },
+    }
+    expect(() => {
+      setConfig(minimalConfig)
+    }).not.toThrow()
   })
 })
 // End: server-side testing

--- a/src/config.js
+++ b/src/config.js
@@ -9,11 +9,9 @@ const TWO_WEEKS_IN_MS = 14 * 60 * 60 * 24 * 1000
 // https://github.com/gladly-team/next-firebase-auth#config
 const defaultConfig = {
   debug: false,
-  // Required string: the API endpoint to call on auth state
-  // change for an authenticated user.
+  // The API endpoint to call on auth state change for an authenticated user.
   loginAPIEndpoint: undefined,
-  // Required string: the API endpoint to call on auth state
-  // change for a signed-out user.
+  // The API endpoint to call on auth state change for a signed-out user.
   logoutAPIEndpoint: undefined,
   // Optional function: handler called if the login API endpoint returns
   // a non-200 response. Not used if a custom "tokenChangedHandler" is
@@ -59,7 +57,7 @@ const defaultConfig = {
   cookies: {
     // Required string. The base name for the auth cookies.
     name: undefined,
-    // Required string or array.
+    // String or array.
     keys: undefined,
     // Options below are passed to cookies.set:
     // https://github.com/pillarjs/cookies#cookiesset-name--value---options--
@@ -100,13 +98,6 @@ const validateConfig = (mergedConfig) => {
       errorMessages.push(
         'The "onLogoutRequestError" setting should not be set if you are using a "tokenChangedHandler".'
       )
-    }
-  } else {
-    if (!mergedConfig.loginAPIEndpoint) {
-      errorMessages.push('The "loginAPIEndpoint" setting is required.')
-    }
-    if (!mergedConfig.logoutAPIEndpoint) {
-      errorMessages.push('The "logoutAPIEndpoint" setting is required.')
     }
   }
 
@@ -169,6 +160,12 @@ const validateConfig = (mergedConfig) => {
     /**
      * START: config specific to client side
      */
+    if (!mergedConfig.loginAPIEndpoint) {
+      errorMessages.push('The "loginAPIEndpoint" setting is required.')
+    }
+    if (!mergedConfig.logoutAPIEndpoint) {
+      errorMessages.push('The "logoutAPIEndpoint" setting is required.')
+    }
     if (
       mergedConfig.firebaseAdminInitConfig &&
       mergedConfig.firebaseAdminInitConfig.credential &&

--- a/src/config.js
+++ b/src/config.js
@@ -160,12 +160,15 @@ const validateConfig = (mergedConfig) => {
     /**
      * START: config specific to client side
      */
-    if (!mergedConfig.loginAPIEndpoint) {
-      errorMessages.push('The "loginAPIEndpoint" setting is required.')
+    if (!mergedConfig.tokenChangedHandler) {
+      if (!mergedConfig.loginAPIEndpoint) {
+        errorMessages.push('The "loginAPIEndpoint" setting is required.')
+      }
+      if (!mergedConfig.logoutAPIEndpoint) {
+        errorMessages.push('The "logoutAPIEndpoint" setting is required.')
+      }
     }
-    if (!mergedConfig.logoutAPIEndpoint) {
-      errorMessages.push('The "logoutAPIEndpoint" setting is required.')
-    }
+
     if (
       mergedConfig.firebaseAdminInitConfig &&
       mergedConfig.firebaseAdminInitConfig.credential &&


### PR DESCRIPTION
For cases like #223, developers may want to run `next-firebase-auth` exclusively on a server. To support this, client-side dependencies and config settings should be optional.