### PR TITLE
feat(firebaseAdmin): fix to pass user custom user claims to createCustomToken

### DIFF
--- a/src/firebaseAdmin.js
+++ b/src/firebaseAdmin.js
@@ -144,9 +144,13 @@ export const getCustomIdAndRefreshTokens = async (token) => {
   const AuthUser = await verifyIdToken(token)
   const admin = getFirebaseAdminApp()
 
+  const auth = admin.auth()
+
+  const user = await auth.getUser(AuthUser.id)
+
   // It's important that we pass the same user ID here, otherwise
   // Firebase will create a new user.
-  const customToken = await admin.auth().createCustomToken(AuthUser.id)
+  const customToken = await auth.createCustomToken(AuthUser.id, user.customClaims)
 
   // https://firebase.google.com/docs/reference/rest/auth/#section-verify-custom-token
   const firebasePublicAPIKey = getFirebasePublicAPIKey()


### PR DESCRIPTION
As refer to the discussion https://github.com/gladly-team/next-firebase-auth/issues/317, currently we can not retrieve custom user claims that sets on firebase user from the custom token that created in server side. 

So, I added the second argument for adding custom claims.

Please tell me if I send this PR by wrong manner for this repository 🙇 

Thanks for great library!