### PR TITLE
Add more debug logging

### DIFF
--- a/src/__tests__/config.test.js
+++ b/src/__tests__/config.test.js
@@ -904,7 +904,7 @@ describe('config: debug logging', () => {
       },
     }
     expect(logDebug).toHaveBeenCalledWith(
-      'Setting config with provided value:',
+      '[init] Setting config with provided value:',
       expectedConfig
     )
   })
@@ -932,7 +932,7 @@ describe('config: debug logging', () => {
       firebaseAdminInitConfig: undefined,
     }
     expect(logDebug).toHaveBeenCalledWith(
-      'Setting config with provided value:',
+      '[init] Setting config with provided value:',
       expectedConfig
     )
   })
@@ -964,7 +964,7 @@ describe('config: debug logging', () => {
       },
     }
     expect(logDebug).toHaveBeenCalledWith(
-      'Setting config with provided value:',
+      '[init] Setting config with provided value:',
       expectedConfig
     )
   })

--- a/src/__tests__/firebaseAdmin.test.js
+++ b/src/__tests__/firebaseAdmin.test.js
@@ -4,10 +4,9 @@ import createAuthUser from 'src/createAuthUser'
 import { setConfig, getConfig } from 'src/config'
 import createMockConfig from 'src/testHelpers/createMockConfig'
 import getFirebaseAdminApp from 'src/initFirebaseAdminSDK'
+import logDebug from 'src/logDebug'
 
-// TODO: add tests
-// import logDebug from 'src/logDebug'
-
+// FIXME: make init more accurate
 // We're not mocking initFirebaseAdminSDK.js, instead just mocking
 // the underyling Firebase admin app.
 jest.mock('firebase-admin')
@@ -40,6 +39,7 @@ const googleRefreshTokenEndpoint = 'https://securetoken.googleapis.com/v1/token'
 const googleCustomTokenEndpoint =
   'https://identitytoolkit.googleapis.com/v1/accounts:signInWithCustomToken'
 
+/* BEGIN: verifyIdToken tests */
 describe('verifyIdToken', () => {
   it('returns an AuthUser', async () => {
     expect.assertions(1)
@@ -581,8 +581,201 @@ describe('verifyIdToken', () => {
     const token = await AuthUser.getIdToken()
     expect(token).toEqual(null)
   })
-})
 
+  it('logs debugging logs as expected for an authed user', async () => {
+    expect.assertions(3)
+    const { verifyIdToken } = require('src/firebaseAdmin')
+    const mockFirebaseUser = createMockFirebaseUserAdminSDK()
+    const admin = getFirebaseAdminApp()
+    admin.auth().verifyIdToken.mockResolvedValue(mockFirebaseUser)
+
+    logDebug.mockClear()
+    await verifyIdToken('some-token')
+    expect(logDebug).toHaveBeenCalledWith('Initialized the Firebase admin SDK.')
+    expect(logDebug).toHaveBeenCalledWith('Successfully verified the ID token.')
+    expect(logDebug).toHaveBeenCalledTimes(2)
+  })
+
+  it('logs debugging logs as expected if verifying the token fails with auth/invalid-user-token', async () => {
+    expect.assertions(3)
+    const { verifyIdToken } = require('src/firebaseAdmin')
+
+    const expiredTokenErr = new Error('Mock error message.')
+    expiredTokenErr.code = 'auth/invalid-user-token'
+    const mockFirebaseUser = createMockFirebaseUserAdminSDK()
+    const admin = getFirebaseAdminApp()
+    admin.auth().verifyIdToken.mockImplementation(async (token) => {
+      if (token === 'some-token') {
+        throw expiredTokenErr
+      } else {
+        return mockFirebaseUser
+      }
+    })
+    logDebug.mockClear()
+    await verifyIdToken('some-token', 'my-refresh-token')
+    expect(logDebug).toHaveBeenCalledWith('Initialized the Firebase admin SDK.')
+    expect(logDebug).toHaveBeenCalledWith(
+      'Error during verifyIdToken: auth/invalid-user-token. User will be unauthenticated.'
+    )
+    expect(logDebug).toHaveBeenCalledTimes(2)
+  })
+
+  it('logs debugging logs as expected if verifying the token fails with auth/user-token-expired', async () => {
+    expect.assertions(3)
+    const { verifyIdToken } = require('src/firebaseAdmin')
+
+    const expiredTokenErr = new Error('Mock error message.')
+    expiredTokenErr.code = 'auth/user-token-expired'
+    const mockFirebaseUser = createMockFirebaseUserAdminSDK()
+    const admin = getFirebaseAdminApp()
+    admin.auth().verifyIdToken.mockImplementation(async (token) => {
+      if (token === 'some-token') {
+        throw expiredTokenErr
+      } else {
+        return mockFirebaseUser
+      }
+    })
+    logDebug.mockClear()
+    await verifyIdToken('some-token', 'my-refresh-token')
+    expect(logDebug).toHaveBeenCalledWith('Initialized the Firebase admin SDK.')
+    expect(logDebug).toHaveBeenCalledWith(
+      'Error during verifyIdToken: auth/user-token-expired. User will be unauthenticated.'
+    )
+    expect(logDebug).toHaveBeenCalledTimes(2)
+  })
+
+  it('logs debugging logs as expected if verifying the token fails with auth/user-disabled', async () => {
+    expect.assertions(3)
+    const { verifyIdToken } = require('src/firebaseAdmin')
+
+    const expiredTokenErr = new Error('Mock error message.')
+    expiredTokenErr.code = 'auth/user-disabled'
+    const mockFirebaseUser = createMockFirebaseUserAdminSDK()
+    const admin = getFirebaseAdminApp()
+    admin.auth().verifyIdToken.mockImplementation(async (token) => {
+      if (token === 'some-token') {
+        throw expiredTokenErr
+      } else {
+        return mockFirebaseUser
+      }
+    })
+    logDebug.mockClear()
+    await verifyIdToken('some-token', 'my-refresh-token')
+    expect(logDebug).toHaveBeenCalledWith('Initialized the Firebase admin SDK.')
+    expect(logDebug).toHaveBeenCalledWith(
+      'Error during verifyIdToken: auth/user-disabled. User will be unauthenticated.'
+    )
+    expect(logDebug).toHaveBeenCalledTimes(2)
+  })
+
+  it('logs debugging logs as expected when the token is successfully refreshed because of a Firebase auth/argument-error error', async () => {
+    expect.assertions(5)
+    const { verifyIdToken } = require('src/firebaseAdmin')
+
+    // Mock the behavior of refreshing the token.
+    global.fetch.mockImplementation(async (endpoint) => {
+      if (endpoint.indexOf(googleRefreshTokenEndpoint) === 0) {
+        return {
+          ...createMockFetchResponse(),
+          json: () => Promise.resolve({ id_token: 'a-new-token' }),
+        }
+      }
+      // Incorrect endpoint. Return a 500.
+      return { ...createMockFetchResponse(), ok: false, status: 500 }
+    })
+
+    // Mock that the original token is expired but a new token works.
+    const expiredTokenErr = new Error(
+      'Firebase ID token has "kid" claim which does not correspond to a known public key. Most likely the ID token is expired, so get a fresh token from your client app and try again.'
+    )
+    expiredTokenErr.code = 'auth/argument-error'
+    const mockFirebaseUser = createMockFirebaseUserAdminSDK()
+    const admin = getFirebaseAdminApp()
+    admin.auth().verifyIdToken.mockImplementation(async (token) => {
+      if (token === 'some-token') {
+        throw expiredTokenErr
+      } else {
+        return mockFirebaseUser
+      }
+    })
+    logDebug.mockClear()
+    await verifyIdToken('some-token', 'my-refresh-token')
+    expect(logDebug).toHaveBeenCalledWith('Initialized the Firebase admin SDK.')
+    expect(logDebug).toHaveBeenCalledWith(
+      'ID token is expired (error code auth/argument-error). Attempting to refresh the ID token.'
+    )
+    expect(logDebug).toHaveBeenCalledWith(
+      'Successfully refreshed the ID token.'
+    )
+    expect(logDebug).toHaveBeenCalledWith('Successfully verified the ID token.')
+    expect(logDebug).toHaveBeenCalledTimes(4)
+  })
+
+  it('logs debugging logs as expected when there is an error refreshing the token', async () => {
+    expect.assertions(4)
+    const { verifyIdToken } = require('src/firebaseAdmin')
+    global.fetch.mockImplementation(async () => ({
+      ...createMockFetchResponse(),
+      ok: false,
+      status: 500,
+      json: () => Promise.resolve({ error: 'Something happened, sorry.' }),
+    }))
+    const expiredTokenErr = new Error(
+      'The provided Firebase ID token is expired.'
+    )
+    expiredTokenErr.code = 'auth/id-token-expired'
+    const mockFirebaseUser = createMockFirebaseUserAdminSDK()
+    const admin = getFirebaseAdminApp()
+    admin.auth().verifyIdToken.mockImplementation(async (token) => {
+      if (token === 'some-token') {
+        throw expiredTokenErr
+      } else {
+        return mockFirebaseUser
+      }
+    })
+    logDebug.mockClear()
+    await verifyIdToken('some-token', 'my-refresh-token')
+    expect(logDebug).toHaveBeenCalledWith('Initialized the Firebase admin SDK.')
+    expect(logDebug).toHaveBeenCalledWith(
+      'ID token is expired (error code auth/id-token-expired). Attempting to refresh the ID token.'
+    )
+    expect(logDebug).toHaveBeenCalledWith(
+      'Failed to refresh the ID token. The user will be unauthenticated.'
+    )
+    expect(logDebug).toHaveBeenCalledTimes(3)
+  })
+
+  it("logs debugging logs as expected when Firebase admin's verifyIdToken throws an unhandled error code", async () => {
+    expect.assertions(3)
+    const { verifyIdToken } = require('src/firebaseAdmin')
+    global.fetch.mockImplementation(async (endpoint) => {
+      if (endpoint.indexOf(googleRefreshTokenEndpoint) === 0) {
+        return {
+          ...createMockFetchResponse(),
+          json: () => Promise.resolve({ id_token: 'a-new-token' }),
+        }
+      }
+      // Mock a 500 response from Google token refresh.
+      return { ...createMockFetchResponse(), ok: false, status: 500 }
+    })
+    const otherErr = new Error('The Firebase ID token has been revoked.')
+    otherErr.code = 'auth/some-unexpected-error' // a different error
+    const admin = getFirebaseAdminApp()
+    admin.auth().verifyIdToken.mockImplementation(async () => {
+      throw otherErr
+    })
+    logDebug.mockClear()
+    await verifyIdToken('some-token', 'my-refresh-token')
+    expect(logDebug).toHaveBeenCalledWith('Initialized the Firebase admin SDK.')
+    expect(logDebug).toHaveBeenCalledWith(
+      'Error during verifyIdToken: auth/some-unexpected-error. User will be unauthenticated.'
+    )
+    expect(logDebug).toHaveBeenCalledTimes(2)
+  })
+})
+/* END: verifyIdToken tests */
+
+/* BEGIN: getCustomIdAndRefreshTokens tests */
 describe('getCustomIdAndRefreshTokens', () => {
   it("passes the Firebase user's ID (from verifyIdToken) to createCustomToken", async () => {
     expect.assertions(1)
@@ -597,7 +790,7 @@ describe('getCustomIdAndRefreshTokens', () => {
     )
   })
 
-  it('calls the public google endpoint if the firebaseAuthEmulatorHost is not set to get a custom token, including the public Firebase API key as a URL parameter', async () => {
+  it('calls the public Google endpoint if the firebaseAuthEmulatorHost is not set to get a custom token, including the public Firebase API key as a URL parameter', async () => {
     expect.assertions(1)
     const { getCustomIdAndRefreshTokens } = require('src/firebaseAdmin')
 
@@ -727,7 +920,7 @@ describe('getCustomIdAndRefreshTokens', () => {
     })
   })
 
-  it('throws if fetching a custom token fails', async () => {
+  it('throws if fetching a refresh token fails', async () => {
     expect.assertions(1)
     const { getCustomIdAndRefreshTokens } = require('src/firebaseAdmin')
 
@@ -750,4 +943,78 @@ describe('getCustomIdAndRefreshTokens', () => {
       new Error('Problem getting a refresh token: {"error":"Oh no."}')
     )
   })
+
+  it('logs debugging logs as expected', async () => {
+    expect.assertions(5)
+    const { getCustomIdAndRefreshTokens } = require('src/firebaseAdmin')
+
+    // Mock the behavior of getting a custom token.
+    global.fetch.mockReturnValue({
+      ...createMockFetchResponse(),
+      json: () =>
+        Promise.resolve({
+          idToken: 'the-id-token',
+          refreshToken: 'the-refresh-token',
+        }),
+    })
+
+    const mockFirebaseUser = createMockFirebaseUserAdminSDK()
+    const admin = getFirebaseAdminApp()
+    admin.auth().verifyIdToken.mockResolvedValue(mockFirebaseUser)
+    admin.auth().createCustomToken.mockResolvedValue('my-custom-token')
+
+    logDebug.mockClear()
+    await getCustomIdAndRefreshTokens('some-token')
+    expect(logDebug).toHaveBeenCalledWith(
+      'Getting a refresh token from the ID token.'
+    )
+    expect(logDebug).toHaveBeenCalledWith('Initialized the Firebase admin SDK.')
+    expect(logDebug).toHaveBeenCalledWith('Successfully verified the ID token.')
+
+    // FIXME: edit after improving admin mock
+    expect(logDebug).toHaveBeenCalledWith('Initialized the Firebase admin SDK.')
+    expect(logDebug).toHaveBeenCalledTimes(4)
+  })
+
+  it('logs debugging logs as expected when failing to get a refresh token', async () => {
+    expect.assertions(6)
+    const { getCustomIdAndRefreshTokens } = require('src/firebaseAdmin')
+
+    // Mock the behavior of getting a custom token.
+    global.fetch.mockReturnValue({
+      ...createMockFetchResponse(),
+      ok: false,
+      status: 500,
+      json: () =>
+        Promise.resolve({
+          error: 'Oh no.',
+        }),
+    })
+
+    const mockFirebaseUser = createMockFirebaseUserAdminSDK()
+    const admin = getFirebaseAdminApp()
+    admin.auth().verifyIdToken.mockResolvedValue(mockFirebaseUser)
+    admin.auth().createCustomToken.mockResolvedValue('my-custom-token')
+
+    logDebug.mockClear()
+    try {
+      await getCustomIdAndRefreshTokens('some-token')
+
+      // We expect this to throw.
+      // eslint-disable-next-line no-empty
+    } catch (e) {}
+    expect(logDebug).toHaveBeenCalledWith(
+      'Getting a refresh token from the ID token.'
+    )
+    expect(logDebug).toHaveBeenCalledWith('Initialized the Firebase admin SDK.')
+    expect(logDebug).toHaveBeenCalledWith('Successfully verified the ID token.')
+
+    // FIXME: edit after improving admin mock
+    expect(logDebug).toHaveBeenCalledWith('Initialized the Firebase admin SDK.')
+    expect(logDebug).toHaveBeenCalledWith(
+      'Failed to get a refresh token from the ID token.'
+    )
+    expect(logDebug).toHaveBeenCalledTimes(5)
+  })
 })
+/* END: getCustomIdAndRefreshTokens tests */

--- a/src/__tests__/firebaseAdmin.test.js
+++ b/src/__tests__/firebaseAdmin.test.js
@@ -592,7 +592,9 @@ describe('verifyIdToken', () => {
 
     logDebug.mockClear()
     await verifyIdToken('some-token')
-    expect(logDebug).toHaveBeenCalledWith('Successfully verified the ID token.')
+    expect(logDebug).toHaveBeenCalledWith(
+      '[verifyIdToken] Successfully verified the ID token. The user is authenticated.'
+    )
     expect(logDebug).toHaveBeenCalledTimes(1)
   })
 
@@ -614,7 +616,7 @@ describe('verifyIdToken', () => {
     logDebug.mockClear()
     await verifyIdToken('some-token', 'my-refresh-token')
     expect(logDebug).toHaveBeenCalledWith(
-      'Error during verifyIdToken: auth/invalid-user-token. User will be unauthenticated.'
+      '[verifyIdToken] Error verifying the ID token: auth/invalid-user-token. The user will be unauthenticated.'
     )
     expect(logDebug).toHaveBeenCalledTimes(1)
   })
@@ -637,7 +639,7 @@ describe('verifyIdToken', () => {
     logDebug.mockClear()
     await verifyIdToken('some-token', 'my-refresh-token')
     expect(logDebug).toHaveBeenCalledWith(
-      'Error during verifyIdToken: auth/user-token-expired. User will be unauthenticated.'
+      '[verifyIdToken] Error verifying the ID token: auth/user-token-expired. The user will be unauthenticated.'
     )
     expect(logDebug).toHaveBeenCalledTimes(1)
   })
@@ -660,7 +662,7 @@ describe('verifyIdToken', () => {
     logDebug.mockClear()
     await verifyIdToken('some-token', 'my-refresh-token')
     expect(logDebug).toHaveBeenCalledWith(
-      'Error during verifyIdToken: auth/user-disabled. User will be unauthenticated.'
+      '[verifyIdToken] Error verifying the ID token: auth/user-disabled. The user will be unauthenticated.'
     )
     expect(logDebug).toHaveBeenCalledTimes(1)
   })
@@ -698,12 +700,14 @@ describe('verifyIdToken', () => {
     logDebug.mockClear()
     await verifyIdToken('some-token', 'my-refresh-token')
     expect(logDebug).toHaveBeenCalledWith(
-      'ID token is expired (error code auth/argument-error). Attempting to refresh the ID token.'
+      '[verifyIdToken] The ID token is expired (error code auth/argument-error). Attempting to refresh the ID token.'
     )
     expect(logDebug).toHaveBeenCalledWith(
-      'Successfully refreshed the ID token.'
+      '[verifyIdToken] Successfully refreshed the ID token.'
     )
-    expect(logDebug).toHaveBeenCalledWith('Successfully verified the ID token.')
+    expect(logDebug).toHaveBeenCalledWith(
+      '[verifyIdToken] Successfully verified the ID token. The user is authenticated.'
+    )
     expect(logDebug).toHaveBeenCalledTimes(3)
   })
 
@@ -732,10 +736,10 @@ describe('verifyIdToken', () => {
     logDebug.mockClear()
     await verifyIdToken('some-token', 'my-refresh-token')
     expect(logDebug).toHaveBeenCalledWith(
-      'ID token is expired (error code auth/id-token-expired). Attempting to refresh the ID token.'
+      '[verifyIdToken] The ID token is expired (error code auth/id-token-expired). Attempting to refresh the ID token.'
     )
     expect(logDebug).toHaveBeenCalledWith(
-      'Failed to refresh the ID token. The user will be unauthenticated.'
+      '[verifyIdToken] Failed to refresh the ID token. The user will be unauthenticated.'
     )
     expect(logDebug).toHaveBeenCalledTimes(2)
   })
@@ -762,7 +766,7 @@ describe('verifyIdToken', () => {
     logDebug.mockClear()
     await verifyIdToken('some-token', 'my-refresh-token')
     expect(logDebug).toHaveBeenCalledWith(
-      'Error during verifyIdToken: auth/some-unexpected-error. User will be unauthenticated.'
+      '[verifyIdToken] Error verifying the ID token: auth/some-unexpected-error. The user will be unauthenticated.'
     )
     expect(logDebug).toHaveBeenCalledTimes(1)
   })
@@ -960,9 +964,11 @@ describe('getCustomIdAndRefreshTokens', () => {
     logDebug.mockClear()
     await getCustomIdAndRefreshTokens('some-token')
     expect(logDebug).toHaveBeenCalledWith(
-      'Getting a refresh token from the ID token.'
+      '[setAuthCookies] Getting a refresh token from the ID token.'
     )
-    expect(logDebug).toHaveBeenCalledWith('Successfully verified the ID token.')
+    expect(logDebug).toHaveBeenCalledWith(
+      '[verifyIdToken] Successfully verified the ID token. The user is authenticated.'
+    )
     expect(logDebug).toHaveBeenCalledTimes(2)
   })
 
@@ -994,11 +1000,13 @@ describe('getCustomIdAndRefreshTokens', () => {
       // eslint-disable-next-line no-empty
     } catch (e) {}
     expect(logDebug).toHaveBeenCalledWith(
-      'Getting a refresh token from the ID token.'
+      '[setAuthCookies] Getting a refresh token from the ID token.'
     )
-    expect(logDebug).toHaveBeenCalledWith('Successfully verified the ID token.')
     expect(logDebug).toHaveBeenCalledWith(
-      'Failed to get a refresh token from the ID token.'
+      '[verifyIdToken] Successfully verified the ID token. The user is authenticated.'
+    )
+    expect(logDebug).toHaveBeenCalledWith(
+      '[setAuthCookies] Failed to get a refresh token from the ID token.'
     )
     expect(logDebug).toHaveBeenCalledTimes(3)
   })

--- a/src/__tests__/firebaseAdmin.test.js
+++ b/src/__tests__/firebaseAdmin.test.js
@@ -5,9 +5,13 @@ import { setConfig, getConfig } from 'src/config'
 import createMockConfig from 'src/testHelpers/createMockConfig'
 import getFirebaseAdminApp from 'src/initFirebaseAdminSDK'
 
+// TODO: add tests
+// import logDebug from 'src/logDebug'
+
 // We're not mocking initFirebaseAdminSDK.js, instead just mocking
 // the underyling Firebase admin app.
 jest.mock('firebase-admin')
+jest.mock('src/logDebug')
 
 // stash and restore the system env vars
 let env = null

--- a/src/__tests__/getUserFromCookies.test.js
+++ b/src/__tests__/getUserFromCookies.test.js
@@ -12,23 +12,19 @@ import {
   getAuthUserTokensCookieName,
   getAuthUserTokensSigCookieName,
 } from 'src/authCookies'
-
-jest.mock('src/cookies')
-jest.mock('src/firebaseAdmin')
-jest.mock('src/authCookies')
-jest.mock('src/isClientSide')
+import logDebug from 'src/logDebug'
 
 /**
  * We intentionally don't mock a few modules whose behavior we want to
  * test:
  * - createAuthUser
  * - src/config
- * - getUserFromCookies
  */
 jest.mock('src/cookies')
 jest.mock('src/firebaseAdmin')
 jest.mock('src/authCookies')
 jest.mock('src/isClientSide')
+jest.mock('src/logDebug')
 
 beforeEach(() => {
   // This is always called server-side.
@@ -316,6 +312,116 @@ describe('getUserFromCookies: with ID token', () => {
       new Error('Either "req" or "authCookieValue" must be provided.')
     )
   })
+
+  it('logs expected debug logs for an authenticated user', async () => {
+    expect.assertions(4)
+
+    getCookie.mockImplementation((cookieName) => {
+      if (cookieName === 'SomeName.AuthUserTokens') {
+        return JSON.stringify({
+          idToken: 'some-id-token',
+          refreshToken: 'some-refresh-token',
+        })
+      }
+      if (cookieName === 'SomeName.AuthUser') {
+        return createAuthUser({
+          firebaseUserAdminSDK: createMockFirebaseUserAdminSDK(),
+        }).serialize()
+      }
+      return undefined
+    })
+
+    // Mock the Firebase admin user verification.
+    const mockFirebaseAdminUser = createMockFirebaseUserAdminSDK()
+    const expectedUser = createAuthUser({
+      token: 'a-user-identity-token-abc',
+      firebaseUserAdminSDK: mockFirebaseAdminUser,
+    })
+    verifyIdToken.mockResolvedValue(expectedUser)
+    const mockReq = {}
+
+    logDebug.mockClear()
+    await getUserFromCookies({ req: mockReq })
+    expect(logDebug).toHaveBeenCalledWith(
+      'getUserFromCookies: Attempting to get user info from cookies via the ID token.'
+    )
+    expect(logDebug).toHaveBeenCalledWith(
+      'getUserFromCookies: Successfully retrieved the ID token from cookies.'
+    )
+    expect(logDebug).toHaveBeenCalledWith(
+      'getUserFromCookies: Successfully verified the ID token. The user is authenticated.'
+    )
+    expect(logDebug).toHaveBeenCalledTimes(3)
+  })
+
+  it('logs expected debug logs for a user without valid auth cookie values', async () => {
+    expect.assertions(3)
+    getCookie.mockImplementation((cookieName) => {
+      if (cookieName === 'SomeName.AuthUserTokens') {
+        return JSON.stringify({
+          idToken: 'some-id-token',
+          refreshToken: 'some-refresh-token',
+        })
+      }
+      if (cookieName === 'SomeName.AuthUser') {
+        return createAuthUser({
+          firebaseUserAdminSDK: createMockFirebaseUserAdminSDK(),
+        }).serialize()
+      }
+      return undefined
+    })
+    getCookie.mockReturnValue(undefined) // the user has no auth cookies
+    const mockFirebaseAdminUser = undefined
+    verifyIdToken.mockResolvedValue(mockFirebaseAdminUser)
+    const mockReq = {}
+
+    logDebug.mockClear()
+    await getUserFromCookies({ req: mockReq })
+    expect(logDebug).toHaveBeenCalledWith(
+      'getUserFromCookies: Attempting to get user info from cookies via the ID token.'
+    )
+    expect(logDebug).toHaveBeenCalledWith(
+      'getUserFromCookies: Failed to retrieve the ID token from cookies. The provided cookie values might be invalid or not align with your cookie settings. The user will be unauthenticated.'
+    )
+    expect(logDebug).toHaveBeenCalledTimes(2)
+  })
+
+  it('logs expected debug logs for a user whose ID token is not successfully verified', async () => {
+    expect.assertions(4)
+
+    getCookie.mockImplementation((cookieName) => {
+      if (cookieName === 'SomeName.AuthUserTokens') {
+        return JSON.stringify({
+          idToken: 'some-id-token',
+          refreshToken: 'some-refresh-token',
+        })
+      }
+      if (cookieName === 'SomeName.AuthUser') {
+        return createAuthUser({
+          firebaseUserAdminSDK: createMockFirebaseUserAdminSDK(),
+        }).serialize()
+      }
+      return undefined
+    })
+
+    // Mock the Firebase admin user verification.
+    const expectedUser = createAuthUser() // unauthenticated user!
+    verifyIdToken.mockResolvedValue(expectedUser)
+    const mockReq = {}
+
+    logDebug.mockClear()
+    await getUserFromCookies({ req: mockReq })
+    expect(logDebug).toHaveBeenCalledWith(
+      'getUserFromCookies: Attempting to get user info from cookies via the ID token.'
+    )
+    expect(logDebug).toHaveBeenCalledWith(
+      'getUserFromCookies: Successfully retrieved the ID token from cookies.'
+    )
+    expect(logDebug).toHaveBeenCalledWith(
+      'getUserFromCookies: Failed to verify the ID token. The user will be unauthenticated.'
+    )
+    expect(logDebug).toHaveBeenCalledTimes(3)
+  })
 })
 /**
  * END: tests with ID token
@@ -591,6 +697,62 @@ describe('getUserFromCookies: *without* ID token', () => {
     ).rejects.toThrow(
       new Error('Either "req" or "authCookieValue" must be provided.')
     )
+  })
+
+  it('logs expected debug logs for an authenticated user', async () => {
+    expect.assertions(3)
+
+    getCookie.mockImplementation((cookieName) => {
+      if (cookieName === 'SomeName.AuthUserTokens') {
+        return JSON.stringify({
+          idToken: 'some-id-token',
+          refreshToken: 'some-refresh-token',
+        })
+      }
+      if (cookieName === 'SomeName.AuthUser') {
+        return createAuthUser({
+          firebaseUserAdminSDK: createMockFirebaseUserAdminSDK(),
+        }).serialize()
+      }
+      return undefined
+    })
+
+    // Mock the Firebase admin user verification.
+    const mockFirebaseAdminUser = createMockFirebaseUserAdminSDK()
+    const expectedUser = createAuthUser({
+      token: 'a-user-identity-token-abc',
+      firebaseUserAdminSDK: mockFirebaseAdminUser,
+    })
+    verifyIdToken.mockResolvedValue(expectedUser)
+    const mockReq = {}
+
+    logDebug.mockClear()
+    await getUserFromCookies({ req: mockReq, includeToken: false })
+    expect(logDebug).toHaveBeenCalledWith(
+      'getUserFromCookies: Attempting to get user info from cookies (not using the ID token).'
+    )
+    expect(logDebug).toHaveBeenCalledWith(
+      'getUserFromCookies: Successfully retrieved the user info from cookies.'
+    )
+    expect(logDebug).toHaveBeenCalledTimes(2)
+  })
+
+  it('logs expected debug logs for an unauthenticated user', async () => {
+    expect.assertions(3)
+    getCookie.mockReturnValue(undefined) // the user has no auth cookies
+    const mockFirebaseAdminUser = undefined
+    verifyIdToken.mockResolvedValue(mockFirebaseAdminUser)
+    const mockReq = {}
+
+    logDebug.mockClear()
+    await getUserFromCookies({ req: mockReq, includeToken: false })
+    expect(logDebug).toHaveBeenCalledWith(
+      'getUserFromCookies: Attempting to get user info from cookies (not using the ID token).'
+    )
+    expect(logDebug).toHaveBeenCalledWith(
+      'getUserFromCookies: Failed to retrieve the user info from cookies. The provided cookie values might be invalid or not align with your cookie settings. The user will be unauthenticated.'
+    )
+    expect(logDebug).toHaveBeenCalledTimes(2)
   })
 })
 /**

--- a/src/__tests__/getUserFromCookies.test.js
+++ b/src/__tests__/getUserFromCookies.test.js
@@ -314,7 +314,7 @@ describe('getUserFromCookies: with ID token', () => {
   })
 
   it('logs expected debug logs for an authenticated user', async () => {
-    expect.assertions(4)
+    expect.assertions(3)
 
     getCookie.mockImplementation((cookieName) => {
       if (cookieName === 'SomeName.AuthUserTokens') {
@@ -343,15 +343,12 @@ describe('getUserFromCookies: with ID token', () => {
     logDebug.mockClear()
     await getUserFromCookies({ req: mockReq })
     expect(logDebug).toHaveBeenCalledWith(
-      'getUserFromCookies: Attempting to get user info from cookies via the ID token.'
+      '[getUserFromCookies] Attempting to get user info from cookies via the ID token.'
     )
     expect(logDebug).toHaveBeenCalledWith(
-      'getUserFromCookies: Successfully retrieved the ID token from cookies.'
+      '[getUserFromCookies] Successfully retrieved the ID token from cookies.'
     )
-    expect(logDebug).toHaveBeenCalledWith(
-      'getUserFromCookies: Successfully verified the ID token. The user is authenticated.'
-    )
-    expect(logDebug).toHaveBeenCalledTimes(3)
+    expect(logDebug).toHaveBeenCalledTimes(2)
   })
 
   it('logs expected debug logs for a user without valid auth cookie values', async () => {
@@ -378,16 +375,16 @@ describe('getUserFromCookies: with ID token', () => {
     logDebug.mockClear()
     await getUserFromCookies({ req: mockReq })
     expect(logDebug).toHaveBeenCalledWith(
-      'getUserFromCookies: Attempting to get user info from cookies via the ID token.'
+      '[getUserFromCookies] Attempting to get user info from cookies via the ID token.'
     )
     expect(logDebug).toHaveBeenCalledWith(
-      'getUserFromCookies: Failed to retrieve the ID token from cookies. The provided cookie values might be invalid or not align with your cookie settings. The user will be unauthenticated.'
+      "[getUserFromCookies] Failed to retrieve the ID token from cookies. This will happen if the user is not logged in, the provided cookie values are invalid, or the cookie values don't align with your cookie settings. The user will be unauthenticated."
     )
     expect(logDebug).toHaveBeenCalledTimes(2)
   })
 
   it('logs expected debug logs for a user whose ID token is not successfully verified', async () => {
-    expect.assertions(4)
+    expect.assertions(3)
 
     getCookie.mockImplementation((cookieName) => {
       if (cookieName === 'SomeName.AuthUserTokens') {
@@ -412,15 +409,12 @@ describe('getUserFromCookies: with ID token', () => {
     logDebug.mockClear()
     await getUserFromCookies({ req: mockReq })
     expect(logDebug).toHaveBeenCalledWith(
-      'getUserFromCookies: Attempting to get user info from cookies via the ID token.'
+      '[getUserFromCookies] Attempting to get user info from cookies via the ID token.'
     )
     expect(logDebug).toHaveBeenCalledWith(
-      'getUserFromCookies: Successfully retrieved the ID token from cookies.'
+      '[getUserFromCookies] Successfully retrieved the ID token from cookies.'
     )
-    expect(logDebug).toHaveBeenCalledWith(
-      'getUserFromCookies: Failed to verify the ID token. The user will be unauthenticated.'
-    )
-    expect(logDebug).toHaveBeenCalledTimes(3)
+    expect(logDebug).toHaveBeenCalledTimes(2)
   })
 })
 /**
@@ -729,10 +723,10 @@ describe('getUserFromCookies: *without* ID token', () => {
     logDebug.mockClear()
     await getUserFromCookies({ req: mockReq, includeToken: false })
     expect(logDebug).toHaveBeenCalledWith(
-      'getUserFromCookies: Attempting to get user info from cookies (not using the ID token).'
+      '[getUserFromCookies] Attempting to get user info from cookies (not using the ID token).'
     )
     expect(logDebug).toHaveBeenCalledWith(
-      'getUserFromCookies: Successfully retrieved the user info from cookies.'
+      '[getUserFromCookies] Successfully retrieved the user info from cookies.'
     )
     expect(logDebug).toHaveBeenCalledTimes(2)
   })
@@ -747,10 +741,10 @@ describe('getUserFromCookies: *without* ID token', () => {
     logDebug.mockClear()
     await getUserFromCookies({ req: mockReq, includeToken: false })
     expect(logDebug).toHaveBeenCalledWith(
-      'getUserFromCookies: Attempting to get user info from cookies (not using the ID token).'
+      '[getUserFromCookies] Attempting to get user info from cookies (not using the ID token).'
     )
     expect(logDebug).toHaveBeenCalledWith(
-      'getUserFromCookies: Failed to retrieve the user info from cookies. The provided cookie values might be invalid or not align with your cookie settings. The user will be unauthenticated.'
+      '[getUserFromCookies] Failed to retrieve the user info from cookies. The provided cookie values might be invalid or not align with your cookie settings. The user will be unauthenticated.'
     )
     expect(logDebug).toHaveBeenCalledTimes(2)
   })

--- a/src/__tests__/initFirebaseAdminSDK.test.js
+++ b/src/__tests__/initFirebaseAdminSDK.test.js
@@ -4,9 +4,11 @@
 import * as admin from 'firebase-admin'
 import { setConfig } from 'src/config'
 import createMockConfig from 'src/testHelpers/createMockConfig'
+import logDebug from 'src/logDebug'
 
 jest.mock('firebase-admin')
 jest.mock('src/config')
+jest.mock('src/logDebug')
 
 beforeEach(() => {
   const mockConfig = createMockConfig({ clientSide: false })
@@ -102,5 +104,22 @@ describe('initFirebaseAdminSDK', () => {
     expect(() => {
       initFirebaseAdminSDK()
     }).not.toThrow()
+  })
+
+  it('calls logDebug when initializing the admin app', () => {
+    expect.assertions(1)
+    const initFirebaseAdminSDK = require('src/initFirebaseAdminSDK').default
+    initFirebaseAdminSDK()
+    expect(logDebug).toHaveBeenCalledWith('Initialized the Firebase admin SDK.')
+  })
+
+  it('call logDebug when not initializing a new app', () => {
+    expect.assertions(1)
+    admin.apps = [{ some: 'app' }]
+    const initFirebaseAdminSDK = require('src/initFirebaseAdminSDK').default
+    initFirebaseAdminSDK()
+    expect(logDebug).toHaveBeenCalledWith(
+      'Did not initialize the Firebase admin SDK because an app already exists.'
+    )
   })
 })

--- a/src/__tests__/initFirebaseAdminSDK.test.js
+++ b/src/__tests__/initFirebaseAdminSDK.test.js
@@ -110,7 +110,9 @@ describe('initFirebaseAdminSDK', () => {
     expect.assertions(1)
     const initFirebaseAdminSDK = require('src/initFirebaseAdminSDK').default
     initFirebaseAdminSDK()
-    expect(logDebug).toHaveBeenCalledWith('Initialized the Firebase admin SDK.')
+    expect(logDebug).toHaveBeenCalledWith(
+      '[init] Initialized the Firebase admin SDK.'
+    )
   })
 
   it('does not call logDebug when not initializing a new app', () => {

--- a/src/__tests__/initFirebaseAdminSDK.test.js
+++ b/src/__tests__/initFirebaseAdminSDK.test.js
@@ -113,13 +113,11 @@ describe('initFirebaseAdminSDK', () => {
     expect(logDebug).toHaveBeenCalledWith('Initialized the Firebase admin SDK.')
   })
 
-  it('call logDebug when not initializing a new app', () => {
+  it('does not call logDebug when not initializing a new app', () => {
     expect.assertions(1)
     admin.apps = [{ some: 'app' }]
     const initFirebaseAdminSDK = require('src/initFirebaseAdminSDK').default
     initFirebaseAdminSDK()
-    expect(logDebug).toHaveBeenCalledWith(
-      'Did not initialize the Firebase admin SDK because an app already exists.'
-    )
+    expect(logDebug).not.toHaveBeenCalled()
   })
 })

--- a/src/__tests__/initFirebaseClientSDK.test.js
+++ b/src/__tests__/initFirebaseClientSDK.test.js
@@ -101,7 +101,9 @@ describe('initFirebaseClientSDK', () => {
     expect.assertions(1)
     const initFirebaseClientSDK = require('src/initFirebaseClientSDK').default
     initFirebaseClientSDK()
-    expect(logDebug).toHaveBeenCalledWith('Initialized the Firebase JS SDK.')
+    expect(logDebug).toHaveBeenCalledWith(
+      '[init] Initialized the Firebase JS SDK.'
+    )
   })
 
   it('calls logDebug when not initializing', () => {
@@ -110,7 +112,7 @@ describe('initFirebaseClientSDK', () => {
     const initFirebaseClientSDK = require('src/initFirebaseClientSDK').default
     initFirebaseClientSDK()
     expect(logDebug).toHaveBeenCalledWith(
-      'Did not initialize the Firebase JS SDK because an app already exists.'
+      '[init] Did not initialize the Firebase JS SDK because an app already exists.'
     )
   })
 })

--- a/src/__tests__/initFirebaseClientSDK.test.js
+++ b/src/__tests__/initFirebaseClientSDK.test.js
@@ -2,10 +2,12 @@ import { getApps, initializeApp } from 'firebase/app'
 import { getAuth, connectAuthEmulator } from 'firebase/auth'
 import { setConfig } from 'src/config'
 import createMockConfig from 'src/testHelpers/createMockConfig'
+import logDebug from 'src/logDebug'
 
 jest.mock('firebase/app')
 jest.mock('firebase/auth')
 jest.mock('src/config')
+jest.mock('src/logDebug')
 
 beforeEach(() => {
   const mockConfig = createMockConfig()
@@ -93,5 +95,22 @@ describe('initFirebaseClientSDK', () => {
 
     initFirebaseClientSDK()
     expect(connectAuthEmulator).not.toHaveBeenCalled()
+  })
+
+  it('calls logDebug when initializing', () => {
+    expect.assertions(1)
+    const initFirebaseClientSDK = require('src/initFirebaseClientSDK').default
+    initFirebaseClientSDK()
+    expect(logDebug).toHaveBeenCalledWith('Initialized Firebase JS SDK.')
+  })
+
+  it('calls logDebug when not initializing', () => {
+    expect.assertions(1)
+    getApps.mockReturnValue([{ some: 'app' }])
+    const initFirebaseClientSDK = require('src/initFirebaseClientSDK').default
+    initFirebaseClientSDK()
+    expect(logDebug).toHaveBeenCalledWith(
+      'Did not initialize Firebase JS SDK because an app already exists.'
+    )
   })
 })

--- a/src/__tests__/initFirebaseClientSDK.test.js
+++ b/src/__tests__/initFirebaseClientSDK.test.js
@@ -101,7 +101,7 @@ describe('initFirebaseClientSDK', () => {
     expect.assertions(1)
     const initFirebaseClientSDK = require('src/initFirebaseClientSDK').default
     initFirebaseClientSDK()
-    expect(logDebug).toHaveBeenCalledWith('Initialized Firebase JS SDK.')
+    expect(logDebug).toHaveBeenCalledWith('Initialized the Firebase JS SDK.')
   })
 
   it('calls logDebug when not initializing', () => {
@@ -110,7 +110,7 @@ describe('initFirebaseClientSDK', () => {
     const initFirebaseClientSDK = require('src/initFirebaseClientSDK').default
     initFirebaseClientSDK()
     expect(logDebug).toHaveBeenCalledWith(
-      'Did not initialize Firebase JS SDK because an app already exists.'
+      'Did not initialize the Firebase JS SDK because an app already exists.'
     )
   })
 })

--- a/src/__tests__/setAuthCookies.test.js
+++ b/src/__tests__/setAuthCookies.test.js
@@ -270,9 +270,11 @@ describe('setAuthCookies', () => {
             authorization: 'some-token-here',
           },
         })
-        expect(logDebug).toHaveBeenCalledWith('Attempting to set auth cookies.')
         expect(logDebug).toHaveBeenCalledWith(
-          'Set auth cookies for an authenticated user.'
+          '[setAuthCookies] Attempting to set auth cookies.'
+        )
+        expect(logDebug).toHaveBeenCalledWith(
+          '[setAuthCookies] Set auth cookies for an authenticated user.'
         )
         expect(logDebug).toHaveBeenCalledTimes(2)
       },
@@ -300,9 +302,11 @@ describe('setAuthCookies', () => {
             authorization: 'some-token-here',
           },
         })
-        expect(logDebug).toHaveBeenCalledWith('Attempting to set auth cookies.')
         expect(logDebug).toHaveBeenCalledWith(
-          'Set auth cookies. The user is not authenticated.'
+          '[setAuthCookies] Attempting to set auth cookies.'
+        )
+        expect(logDebug).toHaveBeenCalledWith(
+          '[setAuthCookies] Set auth cookies. The user is not authenticated.'
         )
         expect(logDebug).toHaveBeenCalledTimes(2)
       },

--- a/src/__tests__/setAuthCookies.test.js
+++ b/src/__tests__/setAuthCookies.test.js
@@ -8,11 +8,14 @@ import {
 import { setConfig } from 'src/config'
 import createMockConfig from 'src/testHelpers/createMockConfig'
 import createMockAuthUser from 'src/testHelpers/createMockAuthUser'
+import logDebug from 'src/logDebug'
+import createAuthUser from 'src/createAuthUser'
 
 jest.mock('src/config')
 jest.mock('src/firebaseAdmin')
 jest.mock('src/authCookies')
 jest.mock('src/cookies')
+jest.mock('src/logDebug')
 
 beforeEach(() => {
   const mockAuthUser = createMockAuthUser()
@@ -248,6 +251,60 @@ describe('setAuthCookies', () => {
             authorization: 'some-token-here',
           },
         })
+      },
+    })
+  })
+
+  it('logs expected debug logs when the user is authenticated', async () => {
+    expect.assertions(3)
+    const setAuthCookies = require('src/setAuthCookies').default
+    await testApiHandler({
+      handler: async (req, res) => {
+        await setAuthCookies(req, res)
+        return res.status(200).end()
+      },
+      test: async ({ fetch }) => {
+        logDebug.mockClear()
+        await fetch({
+          headers: {
+            authorization: 'some-token-here',
+          },
+        })
+        expect(logDebug).toHaveBeenCalledWith('Attempting to set auth cookies.')
+        expect(logDebug).toHaveBeenCalledWith(
+          'Set auth cookies for an authenticated user.'
+        )
+        expect(logDebug).toHaveBeenCalledTimes(2)
+      },
+    })
+  })
+
+  it('logs expected debug logs when the user is not authenticated', async () => {
+    expect.assertions(3)
+    const setAuthCookies = require('src/setAuthCookies').default
+
+    getCustomIdAndRefreshTokens.mockResolvedValue({
+      idToken: null,
+      refreshToken: null,
+      AuthUser: createAuthUser(), // unauthenticated
+    })
+    await testApiHandler({
+      handler: async (req, res) => {
+        await setAuthCookies(req, res)
+        return res.status(200).end()
+      },
+      test: async ({ fetch }) => {
+        logDebug.mockClear()
+        await fetch({
+          headers: {
+            authorization: 'some-token-here',
+          },
+        })
+        expect(logDebug).toHaveBeenCalledWith('Attempting to set auth cookies.')
+        expect(logDebug).toHaveBeenCalledWith(
+          'Set auth cookies. The user is not authenticated.'
+        )
+        expect(logDebug).toHaveBeenCalledTimes(2)
       },
     })
   })

--- a/src/__tests__/unsetAuthCookies.test.js
+++ b/src/__tests__/unsetAuthCookies.test.js
@@ -6,10 +6,12 @@ import { deleteCookie } from 'src/cookies'
 import { testApiHandler } from 'next-test-api-route-handler'
 import { setConfig } from 'src/config'
 import createMockConfig from 'src/testHelpers/createMockConfig'
+import logDebug from 'src/logDebug'
 
 jest.mock('src/config')
 jest.mock('src/authCookies')
 jest.mock('src/cookies')
+jest.mock('src/logDebug')
 
 beforeEach(() => {
   getAuthUserCookieName.mockReturnValue('SomeName.AuthUser')
@@ -111,6 +113,21 @@ describe('unsetAuthCookies', () => {
             signed: true,
           }
         )
+      },
+    })
+  })
+
+  it('logs expected debug logs', async () => {
+    expect.assertions(1)
+    const unsetAuthCookies = require('src/unsetAuthCookies').default
+    await testApiHandler({
+      handler: async (req, res) => {
+        unsetAuthCookies(req, res)
+        return res.status(200).end()
+      },
+      test: async ({ fetch }) => {
+        await fetch()
+        expect(logDebug).toHaveBeenCalledWith('Unset auth cookies.')
       },
     })
   })

--- a/src/__tests__/unsetAuthCookies.test.js
+++ b/src/__tests__/unsetAuthCookies.test.js
@@ -127,7 +127,9 @@ describe('unsetAuthCookies', () => {
       },
       test: async ({ fetch }) => {
         await fetch()
-        expect(logDebug).toHaveBeenCalledWith('Unset auth cookies.')
+        expect(logDebug).toHaveBeenCalledWith(
+          '[unsetAuthCookies] Unset auth cookies.'
+        )
       },
     })
   })

--- a/src/__tests__/withAuthUser.test.js
+++ b/src/__tests__/withAuthUser.test.js
@@ -286,7 +286,9 @@ describe('withAuthUser: rendering/redirecting', () => {
         message="How are you?"
       />
     )
-    expect(logDebug).toHaveBeenCalledWith('Redirecting to login.')
+    expect(logDebug).toHaveBeenCalledWith(
+      '[withAuthUser] Redirecting to login.'
+    )
   })
 
   it('redirects to login on the client side when there is no user and a redirecting strategy is set, but only *after* Firebase initializes and the auth cookie request is complete', () => {
@@ -578,7 +580,7 @@ describe('withAuthUser: rendering/redirecting', () => {
         message="How are you?"
       />
     )
-    expect(logDebug).toHaveBeenCalledWith('Redirecting to app.')
+    expect(logDebug).toHaveBeenCalledWith('[withAuthUser] Redirecting to app.')
   })
 
   it('does not redirect to the app on the server side, even when we will redirect to the app on the client side', () => {
@@ -1376,7 +1378,10 @@ describe('withAuthUser: AuthUser context', () => {
       whenAuthed: AuthAction.RENDER,
     })(AnotherMockComponent)
     render(<MockCompWithUser AuthUserSerialized={MockSerializedAuthUser} />)
-    expect(logDebug).toHaveBeenCalledWith('AuthUser set to:', expectedAuthUser)
+    expect(logDebug).toHaveBeenCalledWith(
+      '[withAuthUser] Set AuthUser to:',
+      expectedAuthUser
+    )
   })
 
   it('provides the same AuthUser object reference after "authRequestCompleted" changes (that is, it does not cause a re-render)', () => {

--- a/src/__tests__/withAuthUserTokenSSR.test.js
+++ b/src/__tests__/withAuthUserTokenSSR.test.js
@@ -512,8 +512,8 @@ describe('withAuthUserTokenSSR: authed user cookies and prop', () => {
     expect(props).toEqual({ notFound: true })
   })
 
-  it('does not log any debug logs when not redirecting (getUserFromCookies.js will provide logs)', async () => {
-    expect.assertions(1)
+  it('logs the expected debug logs when not redirecting', async () => {
+    expect.assertions(2)
     const mockFirebaseAdminUser = createMockFirebaseUserAdminSDK()
     const user = createAuthUser({
       token: 'a-user-identity-token-abc',
@@ -525,11 +525,14 @@ describe('withAuthUserTokenSSR: authed user cookies and prop', () => {
     const func = withAuthUserTokenSSR()(mockGetSSPFunc)
     logDebug.mockClear()
     await func(createMockNextContext())
-    expect(logDebug).not.toHaveBeenCalled()
+    expect(logDebug).toHaveBeenCalledWith(
+      '[withAuthUserSSR] Calling "withAuthUserSSR" / "withAuthUserTokenSSR".'
+    )
+    expect(logDebug).toHaveBeenCalledTimes(1)
   })
 
   it('logs expected debug logs when redirecting to the login URL', async () => {
-    expect.assertions(2)
+    expect.assertions(3)
 
     const withAuthUserTokenSSR = require('src/withAuthUserTokenSSR').default
     const mockGetSSPFunc = jest.fn()
@@ -539,12 +542,17 @@ describe('withAuthUserTokenSSR: authed user cookies and prop', () => {
     })(mockGetSSPFunc)
     logDebug.mockClear()
     await func(createMockNextContext())
-    expect(logDebug).toHaveBeenCalledWith('Redirecting to login.')
-    expect(logDebug).toHaveBeenCalledTimes(1)
+    expect(logDebug).toHaveBeenCalledWith(
+      '[withAuthUserSSR] Calling "withAuthUserSSR" / "withAuthUserTokenSSR".'
+    )
+    expect(logDebug).toHaveBeenCalledWith(
+      '[withAuthUserSSR] Redirecting to login.'
+    )
+    expect(logDebug).toHaveBeenCalledTimes(2)
   })
 
   it('logs expected debug logs when redirecting to the app URL', async () => {
-    expect.assertions(2)
+    expect.assertions(3)
 
     // Mock that the user is authed.
     const mockFirebaseAdminUser = createMockFirebaseUserAdminSDK()
@@ -563,7 +571,12 @@ describe('withAuthUserTokenSSR: authed user cookies and prop', () => {
     })(mockGetSSPFunc)
     logDebug.mockClear()
     await func(createMockNextContext())
-    expect(logDebug).toHaveBeenCalledWith('Redirecting to app.')
-    expect(logDebug).toHaveBeenCalledTimes(1)
+    expect(logDebug).toHaveBeenCalledWith(
+      '[withAuthUserSSR] Calling "withAuthUserSSR" / "withAuthUserTokenSSR".'
+    )
+    expect(logDebug).toHaveBeenCalledWith(
+      '[withAuthUserSSR] Redirecting to app.'
+    )
+    expect(logDebug).toHaveBeenCalledTimes(2)
   })
 })

--- a/src/__tests__/withAuthUserTokenSSR.test.js
+++ b/src/__tests__/withAuthUserTokenSSR.test.js
@@ -5,6 +5,7 @@ import createAuthUser from 'src/createAuthUser'
 import createMockNextContext from 'src/testHelpers/createMockNextContext'
 import AuthAction from 'src/AuthAction'
 import getUserFromCookies from 'src/getUserFromCookies'
+import logDebug from 'src/logDebug'
 
 /**
  * We intentionally don't mock a few modules whose behavior we want to
@@ -14,6 +15,12 @@ import getUserFromCookies from 'src/getUserFromCookies'
  */
 jest.mock('src/cookies')
 jest.mock('src/getUserFromCookies')
+jest.mock('src/logDebug')
+
+beforeEach(() => {
+  // Default to an unauthed user.
+  getUserFromCookies.mockResolvedValue(createAuthUser())
+})
 
 afterEach(() => {
   jest.clearAllMocks()
@@ -98,9 +105,7 @@ describe('withAuthUserTokenSSR: authed user cookies and prop', () => {
       props: { AuthUserSerialized: expectedAuthUserProp },
     })
   })
-})
 
-describe('withAuthUserTokenSSR: redirect and composed prop logic', () => {
   it('redirects to the provided string login URL when the user is not authed and auth *is* required', async () => {
     expect.assertions(1)
 
@@ -505,5 +510,60 @@ describe('withAuthUserTokenSSR: redirect and composed prop logic', () => {
     const func = withAuthUserTokenSSR()(mockGetSSPFunc)
     const props = await func(createMockNextContext())
     expect(props).toEqual({ notFound: true })
+  })
+
+  it('does not log any debug logs when not redirecting (getUserFromCookies.js will provide logs)', async () => {
+    expect.assertions(1)
+    const mockFirebaseAdminUser = createMockFirebaseUserAdminSDK()
+    const user = createAuthUser({
+      token: 'a-user-identity-token-abc',
+      firebaseUserAdminSDK: mockFirebaseAdminUser,
+    })
+    getUserFromCookies.mockResolvedValue(user)
+    const withAuthUserTokenSSR = require('src/withAuthUserTokenSSR').default
+    const mockGetSSPFunc = jest.fn()
+    const func = withAuthUserTokenSSR()(mockGetSSPFunc)
+    logDebug.mockClear()
+    await func(createMockNextContext())
+    expect(logDebug).not.toHaveBeenCalled()
+  })
+
+  it('logs expected debug logs when redirecting to the login URL', async () => {
+    expect.assertions(2)
+
+    const withAuthUserTokenSSR = require('src/withAuthUserTokenSSR').default
+    const mockGetSSPFunc = jest.fn()
+    const func = withAuthUserTokenSSR({
+      whenUnauthed: AuthAction.REDIRECT_TO_LOGIN,
+      authPageURL: '/my-login',
+    })(mockGetSSPFunc)
+    logDebug.mockClear()
+    await func(createMockNextContext())
+    expect(logDebug).toHaveBeenCalledWith('Redirecting to login.')
+    expect(logDebug).toHaveBeenCalledTimes(1)
+  })
+
+  it('logs expected debug logs when redirecting to the app URL', async () => {
+    expect.assertions(2)
+
+    // Mock that the user is authed.
+    const mockFirebaseAdminUser = createMockFirebaseUserAdminSDK()
+    getUserFromCookies.mockResolvedValue(
+      createAuthUser({
+        token: 'a-user-identity-token-abc',
+        firebaseUserAdminSDK: mockFirebaseAdminUser,
+      })
+    )
+
+    const withAuthUserTokenSSR = require('src/withAuthUserTokenSSR').default
+    const mockGetSSPFunc = jest.fn()
+    const func = withAuthUserTokenSSR({
+      whenAuthed: AuthAction.REDIRECT_TO_APP,
+      appPageURL: '/my-app',
+    })(mockGetSSPFunc)
+    logDebug.mockClear()
+    await func(createMockNextContext())
+    expect(logDebug).toHaveBeenCalledWith('Redirecting to app.')
+    expect(logDebug).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/config.js
+++ b/src/config.js
@@ -266,7 +266,7 @@ const replacePrivateValues = (unredactedConfig) => {
 
 export const setConfig = (userConfig = {}) => {
   logDebug(
-    'Setting config with provided value:',
+    '[init] Setting config with provided value:',
     replacePrivateValues(userConfig)
   )
 

--- a/src/createAuthUser.js
+++ b/src/createAuthUser.js
@@ -16,7 +16,7 @@ import { filterStandardClaims } from 'src/claims'
  *   a serialized AuthUser, previously returned from an AuthUser instance's
  *   serialize method.
  *
- * @return {Object|null} AuthUser - The user object.
+ * @return {Object} AuthUser - The user object.
  * @return {Boolean} AuthUser.clientInitialized - This will be true if the
  *   Firebase JS SDK has initialized, meaning we know the AuthUser value
  *   is from the source of truth. Defaults to false.

--- a/src/firebaseAdmin.js
+++ b/src/firebaseAdmin.js
@@ -90,9 +90,6 @@ export const verifyIdToken = async (token, refreshToken = null) => {
 
             // Call developer-provided error callback.
             await onTokenRefreshError(refreshErr)
-            logDebug(
-              `Failed to refresh the ID token. Error code: ${refreshErr.code}`
-            )
           }
 
           if (!newTokenFailure) {
@@ -140,15 +137,16 @@ export const verifyIdToken = async (token, refreshToken = null) => {
 
         // Call developer-provided error callback.
         await onVerifyTokenError(e)
-        logDebug(
-          `Error in verifyIdToken: ${e.code}. User will be unauthenticated.`
-        )
+        logDebug(errorMessageVerifyFailed(e.code))
     }
   }
   const AuthUser = createAuthUser({
     firebaseUserAdminSDK: firebaseUser,
     token: newToken,
   })
+  if (AuthUser.id) {
+    logDebug(`Successfully verified the ID token.`)
+  }
   return AuthUser
 }
 
@@ -165,7 +163,7 @@ export const verifyIdToken = async (token, refreshToken = null) => {
  * @return {Object} response.AuthUser - An AuthUser instance
  */
 export const getCustomIdAndRefreshTokens = async (token) => {
-  logDebug('Getting refresh token from ID token.')
+  logDebug('Getting a refresh token from the ID token.')
 
   const AuthUser = await verifyIdToken(token)
   const admin = getFirebaseAdminApp()
@@ -194,6 +192,7 @@ export const getCustomIdAndRefreshTokens = async (token) => {
   })
   const refreshTokenJSON = await refreshTokenResponse.json()
   if (!refreshTokenResponse.ok) {
+    logDebug('Failed to get a refresh token from the ID token.')
     throw new Error(
       `Problem getting a refresh token: ${JSON.stringify(refreshTokenJSON)}`
     )

--- a/src/firebaseAdmin.js
+++ b/src/firebaseAdmin.js
@@ -144,6 +144,9 @@ export const getCustomIdAndRefreshTokens = async (token) => {
   const AuthUser = await verifyIdToken(token)
   const admin = getFirebaseAdminApp()
 
+  // FIXME: ensure a user is authenticated before proceeding. Issue:
+  // https://github.com/gladly-team/next-firebase-auth/issues/531
+
   // It's important that we pass the same user ID here, otherwise
   // Firebase will create a new user.
   const customToken = await admin.auth().createCustomToken(AuthUser.id)

--- a/src/getUserFromCookies.js
+++ b/src/getUserFromCookies.js
@@ -8,6 +8,7 @@ import {
   getAuthUserTokensSigCookieName,
 } from 'src/authCookies'
 import { getConfig } from 'src/config'
+import logDebug from 'src/logDebug'
 
 /**
  * Given a request object or cookie values, verify and return
@@ -77,6 +78,9 @@ const getUserFromCookies = async ({
   if (includeToken) {
     // Get the user's ID token from a cookie, verify it (refreshing
     // as needed), and return the serialized AuthUser in props.
+    logDebug(
+      'getUserFromCookies: Attempting to get user info from cookies via the ID token.'
+    )
     const cookieValStr = getCookie(
       getAuthUserTokensCookieName(),
       {
@@ -88,8 +92,23 @@ const getUserFromCookies = async ({
       ? JSON.parse(cookieValStr)
       : {}
     if (idToken) {
+      logDebug(
+        'getUserFromCookies: Successfully retrieved the ID token from cookies.'
+      )
       user = await verifyIdToken(idToken, refreshToken)
+      if (user.id) {
+        logDebug(
+          'getUserFromCookies: Successfully verified the ID token. The user is authenticated.'
+        )
+      } else {
+        logDebug(
+          'getUserFromCookies: Failed to verify the ID token. The user will be unauthenticated.'
+        )
+      }
     } else {
+      logDebug(
+        'getUserFromCookies: Failed to retrieve the ID token from cookies. The provided cookie values might be invalid or not align with your cookie settings. The user will be unauthenticated.'
+      )
       user = createAuthUser() // unauthenticated AuthUser
     }
   } else {
@@ -100,6 +119,9 @@ const getUserFromCookies = async ({
 
     // Get the user's info from a cookie, verify it (refreshing
     // as needed), and return the serialized AuthUser in props.
+    logDebug(
+      'getUserFromCookies: Attempting to get user info from cookies (not using the ID token).'
+    )
     const cookieValStr = getCookie(
       getAuthUserCookieName(),
       {
@@ -107,6 +129,15 @@ const getUserFromCookies = async ({
       },
       { keys, secure, signed }
     )
+    if (cookieValStr) {
+      logDebug(
+        'getUserFromCookies: Successfully retrieved the user info from cookies.'
+      )
+    } else {
+      logDebug(
+        'getUserFromCookies: Failed to retrieve the user info from cookies. The provided cookie values might be invalid or not align with your cookie settings. The user will be unauthenticated.'
+      )
+    }
     user = createAuthUser({
       serializedAuthUser: cookieValStr,
     })

--- a/src/getUserFromCookies.js
+++ b/src/getUserFromCookies.js
@@ -79,7 +79,7 @@ const getUserFromCookies = async ({
     // Get the user's ID token from a cookie, verify it (refreshing
     // as needed), and return the serialized AuthUser in props.
     logDebug(
-      'getUserFromCookies: Attempting to get user info from cookies via the ID token.'
+      '[getUserFromCookies] Attempting to get user info from cookies via the ID token.'
     )
     const cookieValStr = getCookie(
       getAuthUserTokensCookieName(),
@@ -93,21 +93,14 @@ const getUserFromCookies = async ({
       : {}
     if (idToken) {
       logDebug(
-        'getUserFromCookies: Successfully retrieved the ID token from cookies.'
+        '[getUserFromCookies] Successfully retrieved the ID token from cookies.'
       )
+
+      // verifyIdToken will provide additional debug logs.
       user = await verifyIdToken(idToken, refreshToken)
-      if (user.id) {
-        logDebug(
-          'getUserFromCookies: Successfully verified the ID token. The user is authenticated.'
-        )
-      } else {
-        logDebug(
-          'getUserFromCookies: Failed to verify the ID token. The user will be unauthenticated.'
-        )
-      }
     } else {
       logDebug(
-        'getUserFromCookies: Failed to retrieve the ID token from cookies. The provided cookie values might be invalid or not align with your cookie settings. The user will be unauthenticated.'
+        "[getUserFromCookies] Failed to retrieve the ID token from cookies. This will happen if the user is not logged in, the provided cookie values are invalid, or the cookie values don't align with your cookie settings. The user will be unauthenticated."
       )
       user = createAuthUser() // unauthenticated AuthUser
     }
@@ -120,7 +113,7 @@ const getUserFromCookies = async ({
     // Get the user's info from a cookie, verify it (refreshing
     // as needed), and return the serialized AuthUser in props.
     logDebug(
-      'getUserFromCookies: Attempting to get user info from cookies (not using the ID token).'
+      '[getUserFromCookies] Attempting to get user info from cookies (not using the ID token).'
     )
     const cookieValStr = getCookie(
       getAuthUserCookieName(),
@@ -131,11 +124,11 @@ const getUserFromCookies = async ({
     )
     if (cookieValStr) {
       logDebug(
-        'getUserFromCookies: Successfully retrieved the user info from cookies.'
+        '[getUserFromCookies] Successfully retrieved the user info from cookies.'
       )
     } else {
       logDebug(
-        'getUserFromCookies: Failed to retrieve the user info from cookies. The provided cookie values might be invalid or not align with your cookie settings. The user will be unauthenticated.'
+        '[getUserFromCookies] Failed to retrieve the user info from cookies. The provided cookie values might be invalid or not align with your cookie settings. The user will be unauthenticated.'
       )
     }
     user = createAuthUser({

--- a/src/initFirebaseAdminSDK.js
+++ b/src/initFirebaseAdminSDK.js
@@ -3,6 +3,7 @@
 
 import * as admin from 'firebase-admin'
 import { getConfig } from 'src/config'
+import logDebug from 'src/logDebug'
 
 const initFirebaseAdminSDK = () => {
   if (!admin.apps.length) {
@@ -21,6 +22,11 @@ const initFirebaseAdminSDK = () => {
             ...firebaseAdminInitConfig.credential,
           }),
     })
+    logDebug('Initialized the Firebase admin SDK.')
+  } else {
+    logDebug(
+      'Did not initialize the Firebase admin SDK because an app already exists.'
+    )
   }
   return admin
 }

--- a/src/initFirebaseAdminSDK.js
+++ b/src/initFirebaseAdminSDK.js
@@ -23,10 +23,6 @@ const initFirebaseAdminSDK = () => {
           }),
     })
     logDebug('Initialized the Firebase admin SDK.')
-  } else {
-    logDebug(
-      'Did not initialize the Firebase admin SDK because an app already exists.'
-    )
   }
   return admin
 }

--- a/src/initFirebaseAdminSDK.js
+++ b/src/initFirebaseAdminSDK.js
@@ -22,7 +22,7 @@ const initFirebaseAdminSDK = () => {
             ...firebaseAdminInitConfig.credential,
           }),
     })
-    logDebug('Initialized the Firebase admin SDK.')
+    logDebug('[init] Initialized the Firebase admin SDK.')
   }
   return admin
 }

--- a/src/initFirebaseClientSDK.js
+++ b/src/initFirebaseClientSDK.js
@@ -12,10 +12,10 @@ export default function initFirebaseClientSDK() {
       )
     }
     initializeApp(firebaseClientInitConfig)
-    logDebug('Initialized Firebase JS SDK.')
+    logDebug('Initialized the Firebase JS SDK.')
   } else {
     logDebug(
-      'Did not initialize Firebase JS SDK because an app already exists.'
+      'Did not initialize the Firebase JS SDK because an app already exists.'
     )
   }
   // If the user has provided the firebaseAuthEmulatorHost address, set the emulator

--- a/src/initFirebaseClientSDK.js
+++ b/src/initFirebaseClientSDK.js
@@ -12,10 +12,10 @@ export default function initFirebaseClientSDK() {
       )
     }
     initializeApp(firebaseClientInitConfig)
-    logDebug('Initialized the Firebase JS SDK.')
+    logDebug('[init] Initialized the Firebase JS SDK.')
   } else {
     logDebug(
-      'Did not initialize the Firebase JS SDK because an app already exists.'
+      '[init] Did not initialize the Firebase JS SDK because an app already exists.'
     )
   }
   // If the user has provided the firebaseAuthEmulatorHost address, set the emulator

--- a/src/initFirebaseClientSDK.js
+++ b/src/initFirebaseClientSDK.js
@@ -1,6 +1,7 @@
 import { getApp, getApps, initializeApp } from 'firebase/app'
 import { getAuth, connectAuthEmulator } from 'firebase/auth'
 import { getConfig } from 'src/config'
+import logDebug from 'src/logDebug'
 
 export default function initFirebaseClientSDK() {
   const { firebaseClientInitConfig, firebaseAuthEmulatorHost } = getConfig()

--- a/src/initFirebaseClientSDK.js
+++ b/src/initFirebaseClientSDK.js
@@ -11,6 +11,11 @@ export default function initFirebaseClientSDK() {
       )
     }
     initializeApp(firebaseClientInitConfig)
+    logDebug('Initialized Firebase JS SDK.')
+  } else {
+    logDebug(
+      'Did not initialize Firebase JS SDK because an app already exists.'
+    )
   }
   // If the user has provided the firebaseAuthEmulatorHost address, set the emulator
   if (firebaseAuthEmulatorHost) {

--- a/src/setAuthCookies.js
+++ b/src/setAuthCookies.js
@@ -5,8 +5,11 @@ import {
   getAuthUserTokensCookieName,
 } from 'src/authCookies'
 import { getConfig } from 'src/config'
+import logDebug from 'src/logDebug'
 
 const setAuthCookies = async (req, res, { token: userProvidedToken } = {}) => {
+  logDebug('Attempting to set auth cookies.')
+
   // This should be the original Firebase ID token from
   // the Firebase JS SDK.
   const token = userProvidedToken || req.headers.authorization
@@ -82,6 +85,12 @@ const setAuthCookies = async (req, res, { token: userProvidedToken } = {}) => {
     },
     cookieOptions
   )
+
+  if (AuthUser.id) {
+    logDebug('Set auth cookies for an authenticated user.')
+  } else {
+    logDebug('Set auth cookies. The user is not authenticated.')
+  }
 
   return {
     idToken,

--- a/src/setAuthCookies.js
+++ b/src/setAuthCookies.js
@@ -8,7 +8,7 @@ import { getConfig } from 'src/config'
 import logDebug from 'src/logDebug'
 
 const setAuthCookies = async (req, res, { token: userProvidedToken } = {}) => {
-  logDebug('Attempting to set auth cookies.')
+  logDebug('[setAuthCookies] Attempting to set auth cookies.')
 
   // This should be the original Firebase ID token from
   // the Firebase JS SDK.
@@ -87,9 +87,11 @@ const setAuthCookies = async (req, res, { token: userProvidedToken } = {}) => {
   )
 
   if (AuthUser.id) {
-    logDebug('Set auth cookies for an authenticated user.')
+    logDebug('[setAuthCookies] Set auth cookies for an authenticated user.')
   } else {
-    logDebug('Set auth cookies. The user is not authenticated.')
+    logDebug(
+      '[setAuthCookies] Set auth cookies. The user is not authenticated.'
+    )
   }
 
   return {

--- a/src/unsetAuthCookies.js
+++ b/src/unsetAuthCookies.js
@@ -39,7 +39,7 @@ const unsetAuthCookies = async (req, res) => {
     },
     cookieOptions
   )
-  logDebug('Unset auth cookies.')
+  logDebug('[unsetAuthCookies] Unset auth cookies.')
 }
 
 export default unsetAuthCookies

--- a/src/unsetAuthCookies.js
+++ b/src/unsetAuthCookies.js
@@ -4,6 +4,7 @@ import {
 } from 'src/authCookies'
 import { getConfig } from 'src/config'
 import { deleteCookie } from 'src/cookies'
+import logDebug from 'src/logDebug'
 
 const unsetAuthCookies = async (req, res) => {
   // Pick a subset of the config.cookies options to
@@ -38,6 +39,7 @@ const unsetAuthCookies = async (req, res) => {
     },
     cookieOptions
   )
+  logDebug('Unset auth cookies.')
 }
 
 export default unsetAuthCookies

--- a/src/withAuthUser.js
+++ b/src/withAuthUser.js
@@ -54,6 +54,8 @@ const withAuthUser =
     LoaderComponent = null,
   } = {}) =>
   (ChildComponent) => {
+    logDebug('[withAuthUser] Calling "withAuthUser".')
+
     // Some dependencies are optional. Throw if they aren't installed
     // when calling this API.
     // https://github.com/gladly-team/next-firebase-auth/issues/502
@@ -161,7 +163,7 @@ const withAuthUser =
         [router]
       )
       const redirectToApp = useCallback(() => {
-        logDebug('Redirecting to app.')
+        logDebug('[withAuthUser] Redirecting to app.')
         const destination = getAppRedirectInfo({
           AuthUser,
           redirectURL: appPageURL,
@@ -170,7 +172,7 @@ const withAuthUser =
         routeToDestination(destination)
       }, [AuthUser, routeToDestination])
       const redirectToLogin = useCallback(() => {
-        logDebug('Redirecting to login.')
+        logDebug('[withAuthUser] Redirecting to login.')
         const destination = getLoginRedirectInfo({
           AuthUser,
           redirectURL: authPageURL,
@@ -234,7 +236,7 @@ const withAuthUser =
         returnVal = comps
       }
 
-      logDebug('AuthUser set to:', AuthUser)
+      logDebug('[withAuthUser] Set AuthUser to:', AuthUser)
 
       return returnVal
     }

--- a/src/withAuthUserTokenSSR.js
+++ b/src/withAuthUserTokenSSR.js
@@ -38,13 +38,16 @@ const withAuthUserTokenSSR =
   ) =>
   (getServerSidePropsFunc) =>
   async (ctx) => {
+    logDebug(
+      '[withAuthUserSSR] Calling "withAuthUserSSR" / "withAuthUserTokenSSR".'
+    )
     const { req } = ctx
     const AuthUser = await getUserFromCookies({ req, includeToken: useToken })
     const AuthUserSerialized = AuthUser.serialize()
 
     // If specified, redirect to the login page if the user is unauthed.
     if (!AuthUser.id && whenUnauthed === AuthAction.REDIRECT_TO_LOGIN) {
-      logDebug('Redirecting to login.')
+      logDebug('[withAuthUserSSR] Redirecting to login.')
       const redirect = getLoginRedirectInfo({
         ctx,
         AuthUser,
@@ -58,7 +61,7 @@ const withAuthUserTokenSSR =
 
     // If specified, redirect to the app page if the user is authed.
     if (AuthUser.id && whenAuthed === AuthAction.REDIRECT_TO_APP) {
-      logDebug('Redirecting to app.')
+      logDebug('[withAuthUserSSR] Redirecting to app.')
       const redirect = getAppRedirectInfo({
         ctx,
         AuthUser,

--- a/src/withAuthUserTokenSSR.js
+++ b/src/withAuthUserTokenSSR.js
@@ -1,6 +1,7 @@
 import getUserFromCookies from 'src/getUserFromCookies'
 import AuthAction from 'src/AuthAction'
 import { getLoginRedirectInfo, getAppRedirectInfo } from 'src/redirects'
+import logDebug from 'src/logDebug'
 
 /**
  * An wrapper for a page's exported getServerSideProps that
@@ -43,6 +44,7 @@ const withAuthUserTokenSSR =
 
     // If specified, redirect to the login page if the user is unauthed.
     if (!AuthUser.id && whenUnauthed === AuthAction.REDIRECT_TO_LOGIN) {
+      logDebug('Redirecting to login.')
       const redirect = getLoginRedirectInfo({
         ctx,
         AuthUser,
@@ -56,6 +58,7 @@ const withAuthUserTokenSSR =
 
     // If specified, redirect to the app page if the user is authed.
     if (AuthUser.id && whenAuthed === AuthAction.REDIRECT_TO_APP) {
+      logDebug('Redirecting to app.')
       const redirect = getAppRedirectInfo({
         ctx,
         AuthUser,


### PR DESCRIPTION
Add more debug logging throughout the app. This is in part related to #531.

Add logs to:
- [x] Init Firebase JS SDK
- [x] Init Firebase admin SDK
- [x] `getUserFromCookies`
- [x] Steps of `firebaseAdmin` -- especially when returning an unauthed user
- [x] `setAuthCookies` and `unsetAuthCookies`
- [x] `withAuthUserTokenSSR`