### PR TITLE
Ensure an ID token is valid before attempting to get a refresh token

### DIFF
--- a/src/__tests__/firebaseAdmin.test.js
+++ b/src/__tests__/firebaseAdmin.test.js
@@ -958,7 +958,7 @@ describe('getCustomIdAndRefreshTokens', () => {
 
     admin.auth().createCustomToken.mockResolvedValue('my-custom-token')
     await expect(getCustomIdAndRefreshTokens('some-token')).rejects.toThrow(
-      '[setAuthCookies] Failed to verify the ID token. Cannot authenticate the user or get a refresh token.'
+      'Failed to verify the ID token.'
     )
   })
 

--- a/src/__tests__/firebaseAdmin.test.js
+++ b/src/__tests__/firebaseAdmin.test.js
@@ -958,7 +958,7 @@ describe('getCustomIdAndRefreshTokens', () => {
 
     admin.auth().createCustomToken.mockResolvedValue('my-custom-token')
     await expect(getCustomIdAndRefreshTokens('some-token')).rejects.toThrow(
-      'Failed to verify ID token.'
+      '[setAuthCookies] Failed to verify the ID token. Cannot authenticate the user or get a refresh token.'
     )
   })
 

--- a/src/__tests__/setAuthCookies.test.js
+++ b/src/__tests__/setAuthCookies.test.js
@@ -348,9 +348,7 @@ describe('setAuthCookies', () => {
     expect.assertions(4)
     const setAuthCookies = require('src/setAuthCookies').default
     getCustomIdAndRefreshTokens.mockRejectedValue(
-      new Error(
-        '[setAuthCookies] Failed to verify the ID token. Cannot authenticate the user or get a refresh token.'
-      )
+      new Error('Failed to verify the ID token.')
     )
     await testApiHandler({
       handler: async (req, res) => {
@@ -368,9 +366,7 @@ describe('setAuthCookies', () => {
           '[setAuthCookies] Attempting to set auth cookies.'
         )
         expect(logDebug).toHaveBeenCalledWith(
-          new Error(
-            '[setAuthCookies] Failed to verify the ID token. Cannot authenticate the user or get a refresh token.'
-          )
+          '[setAuthCookies] Failed to verify the ID token. Cannot authenticate the user or get a refresh token.'
         )
         expect(logDebug).toHaveBeenCalledWith(
           '[setAuthCookies] Set auth cookies. The user is not authenticated.'

--- a/src/__tests__/setAuthCookies.test.js
+++ b/src/__tests__/setAuthCookies.test.js
@@ -255,6 +255,37 @@ describe('setAuthCookies', () => {
     })
   })
 
+  it('returns the expected values when getCustomIdAndRefreshTokens throws', async () => {
+    expect.assertions(1)
+    const setAuthCookies = require('src/setAuthCookies').default
+    getCustomIdAndRefreshTokens.mockRejectedValue(
+      new Error(
+        '[setAuthCookies] Failed to verify the ID token. Cannot authenticate the user or get a refresh token.'
+      )
+    )
+    await testApiHandler({
+      handler: async (req, res) => {
+        const response = await setAuthCookies(req, res)
+        expect(JSON.stringify(response)).toEqual(
+          JSON.stringify({
+            idToken: null,
+            refreshToken: null,
+            AuthUser: createAuthUser(), // unauthed user
+          })
+        )
+        return res.status(200).end()
+      },
+      test: async ({ fetch }) => {
+        logDebug.mockClear()
+        await fetch({
+          headers: {
+            authorization: 'some-token-here',
+          },
+        })
+      },
+    })
+  })
+
   it('logs expected debug logs when the user is authenticated', async () => {
     expect.assertions(3)
     const setAuthCookies = require('src/setAuthCookies').default
@@ -309,6 +340,42 @@ describe('setAuthCookies', () => {
           '[setAuthCookies] Set auth cookies. The user is not authenticated.'
         )
         expect(logDebug).toHaveBeenCalledTimes(2)
+      },
+    })
+  })
+
+  it('logs expected debug logs when getCustomIdAndRefreshTokens throws', async () => {
+    expect.assertions(4)
+    const setAuthCookies = require('src/setAuthCookies').default
+    getCustomIdAndRefreshTokens.mockRejectedValue(
+      new Error(
+        '[setAuthCookies] Failed to verify the ID token. Cannot authenticate the user or get a refresh token.'
+      )
+    )
+    await testApiHandler({
+      handler: async (req, res) => {
+        await setAuthCookies(req, res)
+        return res.status(200).end()
+      },
+      test: async ({ fetch }) => {
+        logDebug.mockClear()
+        await fetch({
+          headers: {
+            authorization: 'some-token-here',
+          },
+        })
+        expect(logDebug).toHaveBeenCalledWith(
+          '[setAuthCookies] Attempting to set auth cookies.'
+        )
+        expect(logDebug).toHaveBeenCalledWith(
+          new Error(
+            '[setAuthCookies] Failed to verify the ID token. Cannot authenticate the user or get a refresh token.'
+          )
+        )
+        expect(logDebug).toHaveBeenCalledWith(
+          '[setAuthCookies] Set auth cookies. The user is not authenticated.'
+        )
+        expect(logDebug).toHaveBeenCalledTimes(3)
       },
     })
   })

--- a/src/firebaseAdmin.js
+++ b/src/firebaseAdmin.js
@@ -168,8 +168,11 @@ export const getCustomIdAndRefreshTokens = async (token) => {
   const AuthUser = await verifyIdToken(token)
   const admin = getFirebaseAdminApp()
 
-  // FIXME: ensure a user is authenticated before proceeding. Issue:
+  // Ensure a user is authenticated before proceeding:
   // https://github.com/gladly-team/next-firebase-auth/issues/531
+  if (!AuthUser.id) {
+    throw new Error('Failed to verify ID token.')
+  }
 
   // Prefixing with "[setAuthCookies]" because that's currently the only
   // use case for using getCustomIdAndRefreshTokens.

--- a/src/firebaseAdmin.js
+++ b/src/firebaseAdmin.js
@@ -164,7 +164,9 @@ export const getCustomIdAndRefreshTokens = async (token) => {
   // Ensure a user is authenticated before proceeding:
   // https://github.com/gladly-team/next-firebase-auth/issues/531
   if (!AuthUser.id) {
-    throw new Error('Failed to verify ID token.')
+    throw new Error(
+      '[setAuthCookies] Failed to verify the ID token. Cannot authenticate the user or get a refresh token.'
+    )
   }
 
   // Prefixing with "[setAuthCookies]" because that's currently the only

--- a/src/firebaseAdmin.js
+++ b/src/firebaseAdmin.js
@@ -112,21 +112,14 @@ export const verifyIdToken = async (token, refreshToken = null) => {
               '[verifyIdToken] Failed to refresh the ID token. The user will be unauthenticated.'
             )
           }
-        } else {
-          // TODO: call `onVerifyTokenError` here. Possibly just continue
-          // on to default case rather than breaking.
-          // https://github.com/gladly-team/next-firebase-auth/issues/531
-
-          // Return an unauthenticated user.
-          newToken = null
-          firebaseUser = null
-          logDebug(errorMessageVerifyFailed(e.code))
+          break
         }
-        break
 
-      // Errors we consider unexpected.
+      // Fall through here if there is no refresh token. Without a refresh
+      // token, an expired ID token is not resolvable.
+      // eslint-disable-next-line no-fallthrough
       default:
-        // Return an unauthenticated user for any other error.
+        // Here, any errors are unexpected. Return an unauthenticated user.
         // Rationale: it's not particularly easy for developers to
         // catch errors in `withAuthUserSSR`, so default to returning
         // an unauthed user and give the developer control over

--- a/src/firebaseAdmin.js
+++ b/src/firebaseAdmin.js
@@ -164,9 +164,7 @@ export const getCustomIdAndRefreshTokens = async (token) => {
   // Ensure a user is authenticated before proceeding:
   // https://github.com/gladly-team/next-firebase-auth/issues/531
   if (!AuthUser.id) {
-    throw new Error(
-      '[setAuthCookies] Failed to verify the ID token. Cannot authenticate the user or get a refresh token.'
-    )
+    throw new Error('Failed to verify the ID token.')
   }
 
   // Prefixing with "[setAuthCookies]" because that's currently the only

--- a/src/setAuthCookies.js
+++ b/src/setAuthCookies.js
@@ -31,7 +31,9 @@ const setAuthCookies = async (req, res, { token: userProvidedToken } = {}) => {
       token
     ))
   } catch (e) {
-    logDebug(e)
+    logDebug(
+      '[setAuthCookies] Failed to verify the ID token. Cannot authenticate the user or get a refresh token.'
+    )
   }
 
   // Pick a subset of the config.cookies options to

--- a/src/setAuthCookies.js
+++ b/src/setAuthCookies.js
@@ -6,6 +6,7 @@ import {
 } from 'src/authCookies'
 import { getConfig } from 'src/config'
 import logDebug from 'src/logDebug'
+import createAuthUser from 'src/createAuthUser'
 
 const setAuthCookies = async (req, res, { token: userProvidedToken } = {}) => {
   logDebug('[setAuthCookies] Attempting to set auth cookies.')
@@ -19,11 +20,19 @@ const setAuthCookies = async (req, res, { token: userProvidedToken } = {}) => {
     )
   }
 
-  // Get a custom ID token and refresh token, given a valid
-  // Firebase ID token.
-  const { idToken, refreshToken, AuthUser } = await getCustomIdAndRefreshTokens(
-    token
-  )
+  // Get a custom ID token and refresh token, given a valid Firebase ID
+  // token. If the token isn't valid, set cookies for an unauthenticated
+  // user.
+  let idToken = null
+  let refreshToken = null
+  let AuthUser = createAuthUser() // default to an unauthed user
+  try {
+    ;({ idToken, refreshToken, AuthUser } = await getCustomIdAndRefreshTokens(
+      token
+    ))
+  } catch (e) {
+    logDebug(e)
+  }
 
   // Pick a subset of the config.cookies options to
   // pass to setCookie.


### PR DESCRIPTION
In addition, call `onVerifyTokenError` when an ID token is invalid and we cannot refresh it.

Closes #531. Improved debug logs were added in #534.