### PR TITLE
v1.x: Reproduce issue #163

### DIFF
--- a/example/pages/test1.js
+++ b/example/pages/test1.js
@@ -16,11 +16,16 @@ const styles = {
 /*
   For issue:
   https://github.com/gladly-team/next-firebase-auth/issues/163
-  
+
   Manually testing, HMR works in:
   - 1.0.0-canary.17
+  - 1.0.0-canary.14
+  - 1.0.0-canary.12 <-- release that fixed it
+
+  HMR does NOT work in:
+  - 1.0.0-canary.11
   - 1.0.0-canary.8
-  - 1.0.0-canary.3
+  - 1.0.0-canary.1
   - 1.0.0-canary.0
 
   This is with other dependencies:
@@ -45,7 +50,7 @@ const Test1 = () => {
         <div style={styles.infoTextContainer}>
           <h3>HMR test 1: with NFA</h3>
           <p>This page is wrapped in `withAuthUser`.</p>
-          <p>To test HMR, click the button then edit this paragraph's text.</p>
+          <p>To test HMR, click the button then edit this paragraph's text!</p>
           <p>Clicks: {clicks}</p>
           <button type="button" onClick={onClick}>
             Click me

--- a/example/pages/test1.js
+++ b/example/pages/test1.js
@@ -13,6 +13,25 @@ const styles = {
   },
 }
 
+/*
+  For issue:
+  https://github.com/gladly-team/next-firebase-auth/issues/163
+  
+  Manually testing, HMR works in:
+  - 1.0.0-canary.17
+  - 1.0.0-canary.8
+  - 1.0.0-canary.3
+  - 1.0.0-canary.0
+
+  This is with other dependencies:
+    "firebase": "^9.9.1",
+    "firebase-admin": "^11.0.0",
+    "next": "12.2.3",
+    "next-absolute-url": "^1.2.2",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "react-firebaseui": "^6.0.0"
+ */
 const Test1 = () => {
   const AuthUser = useAuthUser()
   const [clicks, setClicks] = useState(0)

--- a/example/pages/test1.js
+++ b/example/pages/test1.js
@@ -1,0 +1,45 @@
+import React, { useCallback, useState } from 'react'
+import { withAuthUser, AuthAction, useAuthUser } from 'next-firebase-auth'
+import Header from '../components/Header'
+import DemoPageLinks from '../components/DemoPageLinks'
+import FullPageLoader from '../components/FullPageLoader'
+
+const styles = {
+  content: {
+    padding: 32,
+  },
+  infoTextContainer: {
+    marginBottom: 32,
+  },
+}
+
+const Test1 = () => {
+  const AuthUser = useAuthUser()
+  const [clicks, setClicks] = useState(0)
+  const onClick = useCallback(() => {
+    setClicks((currentClicks) => currentClicks + 1)
+  }, [])
+  return (
+    <div>
+      <Header email={AuthUser.email} signOut={AuthUser.signOut} />
+      <div style={styles.content}>
+        <div style={styles.infoTextContainer}>
+          <h3>HMR test 1: with NFA</h3>
+          <p>This page is wrapped in `withAuthUser`.</p>
+          <p>To test HMR, click the button then edit this paragraph's text.</p>
+          <p>Clicks: {clicks}</p>
+          <button type="button" onClick={onClick}>
+            Click me
+          </button>
+        </div>
+        <DemoPageLinks />
+      </div>
+    </div>
+  )
+}
+
+export default withAuthUser({
+  whenUnauthedBeforeInit: AuthAction.SHOW_LOADER,
+  whenUnauthedAfterInit: AuthAction.REDIRECT_TO_LOGIN,
+  LoaderComponent: FullPageLoader,
+})(Test1)

--- a/example/pages/test2.js
+++ b/example/pages/test2.js
@@ -1,0 +1,39 @@
+import React, { useCallback, useState } from 'react'
+import Header from '../components/Header'
+import DemoPageLinks from '../components/DemoPageLinks'
+
+const styles = {
+  content: {
+    padding: 32,
+  },
+  infoTextContainer: {
+    marginBottom: 32,
+  },
+}
+
+// The same as Test1 but without NFA.
+const Test2 = () => {
+  const [clicks, setClicks] = useState(0)
+  const onClick = useCallback(() => {
+    setClicks((currentClicks) => currentClicks + 1)
+  }, [])
+  return (
+    <div>
+      <Header />
+      <div style={styles.content}>
+        <div style={styles.infoTextContainer}>
+          <h3>HMR test 2: with NFA</h3>
+          <p>This page is NOT wrapped in `withAuthUser`.</p>
+          <p>To test HMR, click the button then edit this paragraph's text!</p>
+          <p>Clicks: {clicks}</p>
+          <button type="button" onClick={onClick}>
+            Click me
+          </button>
+        </div>
+        <DemoPageLinks />
+      </div>
+    </div>
+  )
+}
+
+export default Test2


### PR DESCRIPTION
Conclusion: issue #163 is no longer a problem on v1.x branch with the latest peer dependencies. It was fixed in [v1.0.0-canary.12](https://github.com/gladly-team/next-firebase-auth/releases/tag/v1.0.0-canary.12), possibly because of changing index.server.js to not import from index.js in #512 (but we have not investigated the underlying reason).