### PR TITLE
docs: adds missing import to withAuthUserTokenSSR example

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,7 +303,11 @@ It accepts the following options:
 For example, this page will SSR for authenticated users, fetching props using their Firebase ID token, and will server-side redirect to the login page if the user is not authenticated:
 
 ```jsx
-import { withAuthUser, AuthAction } from 'next-firebase-auth'
+import {
+  useAuthUser,
+  withAuthUser,
+  withAuthUserTokenSSR,
+} from 'next-firebase-auth'
 
 const DemoPage = ({ thing }) => <div>The thing is: {thing}</div>
 


### PR DESCRIPTION
An example in the readme was not importing `withAuthUserTokenSSR`