### PR TITLE
Handle fetch top-level errors

### DIFF
--- a/src/useFirebaseUser.js
+++ b/src/useFirebaseUser.js
@@ -20,29 +20,32 @@ const defaultTokenChangedHandler = async (authUser) => {
     // place we use this logic.
     logDebug('[withAuthUser] Calling the login endpoint.')
     const userToken = await authUser.getIdToken()
-    response = await fetch(loginAPIEndpoint, {
-      method: 'POST',
-      headers: {
-        Authorization: userToken,
-      },
-      credentials: 'include',
-    })
-    if (!response.ok) {
-      const responseJSON = await response.json()
-      logDebug(
-        `[withAuthUser] The call to the login endpoint failed with status ${
-          response.status
-        } and response: ${JSON.stringify(responseJSON)}`
-      )
+    try {
+      response = await fetch(loginAPIEndpoint, {
+        method: 'POST',
+        headers: {
+          Authorization: userToken,
+        },
+        credentials: 'include',
+      })
+      if (!response.ok) {
+        const responseJSON = await response.json()
+        logDebug(
+          `[withAuthUser] The call to the login endpoint failed with status ${
+            response.status
+          } and response: ${JSON.stringify(responseJSON)}`
+        )
 
-      // If the developer provided a handler for login errors,
-      // call it and don't throw.
-      // https://github.com/gladly-team/next-firebase-auth/issues/367
-      const err = new Error(
-        `Received ${
-          response.status
-        } response from login API endpoint: ${JSON.stringify(responseJSON)}`
-      )
+        // If the developer provided a handler for login errors,
+        // call it and don't throw.
+        // https://github.com/gladly-team/next-firebase-auth/issues/367
+        throw new Error(
+          `Received ${
+            response.status
+          } response from login API endpoint: ${JSON.stringify(responseJSON)}`
+        )
+      }
+    } catch (err) {
       if (onLoginRequestError) {
         await onLoginRequestError(err)
       } else {
@@ -52,26 +55,29 @@ const defaultTokenChangedHandler = async (authUser) => {
   } else {
     // If the user is not authed, call logout to unset the cookie.
     logDebug('[withAuthUser] Calling the logout endpoint.')
-    response = await fetch(logoutAPIEndpoint, {
-      method: 'POST',
-      credentials: 'include',
-    })
-    if (!response.ok) {
-      const responseJSON = await response.json()
-      logDebug(
-        `[withAuthUser] The call to the logout endpoint failed with status ${
-          response.status
-        } and response: ${JSON.stringify(responseJSON)}`
-      )
+    try {
+      response = await fetch(logoutAPIEndpoint, {
+        method: 'POST',
+        credentials: 'include',
+      })
+      if (!response.ok) {
+        const responseJSON = await response.json()
+        logDebug(
+          `[withAuthUser] The call to the logout endpoint failed with status ${
+            response.status
+          } and response: ${JSON.stringify(responseJSON)}`
+        )
 
-      // If the developer provided a handler for logout errors,
-      // call it and don't throw.
-      // https://github.com/gladly-team/next-firebase-auth/issues/367
-      const err = new Error(
-        `Received ${
-          response.status
-        } response from logout API endpoint: ${JSON.stringify(responseJSON)}`
-      )
+        // If the developer provided a handler for logout errors,
+        // call it and don't throw.
+        // https://github.com/gladly-team/next-firebase-auth/issues/367
+        throw new Error(
+          `Received ${
+            response.status
+          } response from logout API endpoint: ${JSON.stringify(responseJSON)}`
+        )
+      }
+    } catch (err) {
       if (onLogoutRequestError) {
         await onLogoutRequestError(err)
       } else {


### PR DESCRIPTION
*Diff best viewed in [ignore whitespaces mode](https://github.com/gladly-team/next-firebase-auth/pull/618/files?diff=unified&w=1).*

## Handle fetch top-level errors

This PR wraps the `await fetch` calls to login and logout API endpoints by a `try/catch` block so that we call `onLoginRequestError` and `onLogoutRequestError` not-only in case of HTTP errors, but also in case of network errors (e.g. `fetch` [rejecting](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#checking_that_the_fetch_was_successful) with `TypeError: failed to fetch`), instead of leaving those unhandled.

## ~Retry network errors~

<details>
<summary>Moved to its own PR</summary>

Also in order to mitigate network errors, this PR introduces a retry logic when calling  the login and logout API endpoints, provided by [fetch-retry](https://www.npmjs.com/package/fetch-retry).

This module defaults to retrying up to 3 times at 1s intervals, and only retrying network errors (the case where `fetch` rejects, as opposed to HTTP errors where it resolves with `response.ok = false`).

I think those defaults are sensible, and I added a configuration option `fetchRetryConfig` to allow fine tuning the retry logic if needed.

</details>

---

I think the rate of fetch network errors I'm seeing on login API calls is exacerbated by the fact the login API is called on every page (https://github.com/gladly-team/next-firebase-auth/issues/424 - I tried coming up with a solution for that too but didn't find a reliable way to do that just yet), nevertheless this PR shouldn't leave those errors _unhandled_, and thanks to the retry logic, should lower their frequency.

Let me know what you think and if you need me to make any edits!