### PR TITLE
feat(firebaseAdmin): fix to pass user custom user claims to createCustomToken

### DIFF
--- a/__mocks__/firebase-admin.js
+++ b/__mocks__/firebase-admin.js
@@ -3,6 +3,7 @@ const firebaseAdminMock = jest.createMockFromModule('firebase-admin')
 const mockAuthValue = {
   createCustomToken: jest.fn(() => Promise.resolve(null)),
   verifyIdToken: jest.fn(() => Promise.resolve(null)),
+  getUser: jest.fn(() => Promise.resolve(null)),
 }
 firebaseAdminMock.auth = jest.fn(() => mockAuthValue)
 

--- a/src/firebaseAdmin.js
+++ b/src/firebaseAdmin.js
@@ -146,7 +146,10 @@ export const getCustomIdAndRefreshTokens = async (token) => {
 
   // It's important that we pass the same user ID here, otherwise
   // Firebase will create a new user.
-  const customToken = await admin.auth().createCustomToken(AuthUser.id)
+
+  const auth = admin.auth()
+  const firebaseUser = await auth.getUser(AuthUser.id)
+  const customToken = await auth.createCustomToken(AuthUser.id, firebaseUser.customClaims)
 
   // https://firebase.google.com/docs/reference/rest/auth/#section-verify-custom-token
   const firebasePublicAPIKey = getFirebasePublicAPIKey()

--- a/src/testHelpers/authUserInputs.js
+++ b/src/testHelpers/authUserInputs.js
@@ -29,6 +29,24 @@ export const createMockFirebaseUserAdminSDK = () => ({
   // ... other properties
 })
 
+export const createMockFirebaseUserRecord = () => ({
+  customClaims: {},
+  disabled: false,
+  displayName: 'Ghi Jkl',
+  email: '',
+  emailVerified: false,
+  metadata: {
+    creationTime: '2019-01-01T00:00:00.000Z',
+    lastSignInTime: '2019-01-01T00:00:00.000Z',
+  },
+  phoneNumber: '',
+  photoURL: '',
+  providerData: [],
+  tokensValidAfterTime: '2019-01-01T00:00:00.000Z',
+  uid: 'ghi-789',
+  // ... other properties
+})
+
 // https://firebase.google.com/docs/reference/js/firebase.auth.IDTokenResult
 export const createMockIdTokenResult = ({ claims = {} } = {}) => ({
   authTime: 1540000000,


### PR DESCRIPTION
Continuation of @takashi's PR #495.
... And then it was easier to reimplement the code on the v1.x branch based on feedback in #654 