### PR TITLE
Fix typo in v1.x migration documentation

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -61,7 +61,7 @@ Codemod:
 npx -p next-firebase-auth codemod withauthuserssr-to-withuserssr .
 ```
 
-#### `useAuthUser` has become `useAuthUser`
+#### `useAuthUser` has become `useUser`
 
 Codemod:
 


### PR DESCRIPTION
Correct a typo for migration from `useAuthUser` to `useUser`