### PR TITLE
Remove firebaseClientInitConfig from types

### DIFF
--- a/src/configTypes.ts
+++ b/src/configTypes.ts
@@ -72,24 +72,6 @@ export interface ConfigInput {
    * https://firebase.google.com/docs/emulator-suite/connect_auth
    */
   firebaseAuthEmulatorHost?: string
-  /**
-   * The config passed to the Firebase client JS SDK's `initializeApp`.
-   */
-  firebaseClientInitConfig: {
-    apiKey: string
-    projectId?: string
-    appId?: string
-    // "PROJECT_ID.firebaseapp.com"
-    authDomain?: string
-    // "https://PROJECT_ID.firebaseio.com"
-    databaseURL?: string
-    // "PROJECT_ID.appspot.com"
-    storageBucket?: string
-    // "SENDER_ID"
-    messagingSenderId?: string
-    // "G-MEASUREMENT_ID"
-    measurementId?: string
-  }
   tenantId?: string
   cookies: Omit<Cookies.Option & Cookies.SetOption, 'sameSite'> & {
     // The base name for the auth cookies.


### PR DESCRIPTION
After #702, we still need to remove `firebaseClientInitConfig` from the types, as it was moved out of `init()`.

<img width="1003" alt="image" src="https://github.com/gladly-team/next-firebase-auth/assets/18680169/d171a3fd-147f-4891-b837-31392176c64b">
